### PR TITLE
refactor: remove old nitro related code

### DIFF
--- a/src/tinfoil/attestation/attestation.py
+++ b/src/tinfoil/attestation/attestation.py
@@ -16,7 +16,6 @@ from .verify import Report, verify_attestation, CertificateChain
 
 class PredicateType(str, Enum):
     """Predicate types for attestation"""
-    AWS_NITRO_ENCLAVE_V1 = "https://tinfoil.sh/predicate/aws-nitro-enclave/v1"
     SEV_GUEST_V1 = "https://tinfoil.sh/predicate/sev-snp-guest/v1"
 
 ATTESTATION_ENDPOINT = "/.well-known/tinfoil-attestation"

--- a/src/tinfoil/sigstore.py
+++ b/src/tinfoil/sigstore.py
@@ -88,16 +88,7 @@ def verify_attestation(bundle_json: bytes, digest: str, repo: str) -> Measuremen
             )
         
         # Convert predicate type to measurement type
-        if predicate_type == PredicateType.AWS_NITRO_ENCLAVE_V1:
-            try:
-                registers = [
-                    predicate_fields["PCR0"],
-                    predicate_fields["PCR1"],
-                    predicate_fields["PCR2"],
-                ]
-            except KeyError:
-                raise ValueError("AWS Nitro Enclave V1 predicate does not contain PCR0, PCR1, or PCR2")
-        elif predicate_type == PredicateType.SEV_GUEST_V1:
+        if predicate_type == PredicateType.SEV_GUEST_V1:
             try:
                 registers = [predicate_fields["measurement"]]
             except KeyError:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed AWS Nitro Enclave v1 attestation support and related code to simplify verification. Attestation verification now only supports SEV-SNP guest predicates.

- **Refactors**
  - Removed PredicateType.AWS_NITRO_ENCLAVE_V1.
  - Deleted PCR0/1/2 handling in verify_attestation; only SEV_GUEST_V1 measurement is parsed.

- **Migration**
  - Nitro attestations are no longer supported. Pin to a previous version if needed.

<!-- End of auto-generated description by cubic. -->

