### PR TITLE
Re-verify attestation on TLS certificate rotation

### DIFF
--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -217,14 +217,41 @@ class SecureClient:
         handler = TLSBoundHTTPSHandler(self._ground_truth.public_key)
         return urllib.request.build_opener(handler)
 
+    def reverify(self) -> GroundTruth:
+        """Force re-verification of the enclave attestation.
+
+        Use this after a certificate rotation causes connection failures.
+        For httpx clients, call this then create a new client via
+        make_secure_http_client() or make_secure_async_http_client().
+        """
+        self._ground_truth = None
+        return self.verify()
+
     def make_request(self, req: urllib.request.Request) -> Response:
-        """Makes an HTTP request using the secure client"""
-        client = self.get_http_client()
-        
+        """Makes an HTTP request using the secure client.
+
+        If the request fails with a connection or certificate error (e.g. TLS
+        certificate rotation), performs full re-attestation and retries once.
+        If re-verification fails, the original error is raised.
+        """
         # If URL doesn't have a host, assume it's relative to the enclave
         if not urlparse(req.full_url).netloc:
             req.full_url = f"https://{self.enclave}{req.full_url}"
-        
+
+        try:
+            return self._send_request(req)
+        except ValueError as first_err:
+            # Certificate fingerprint mismatch — attempt re-verification and retry once.
+            # If re-verification fails, return the original error.
+            try:
+                self.reverify()
+            except Exception:
+                raise first_err from None
+            return self._send_request(req)
+
+    def _send_request(self, req: urllib.request.Request) -> Response:
+        """Send a single request using the current pinned client."""
+        client = self.get_http_client()
         with client.open(req) as resp:
             return Response(
                 status=f"{resp.status} {resp.reason}",

--- a/tests/test_verification_failures.py
+++ b/tests/test_verification_failures.py
@@ -11,6 +11,7 @@ connections to proceed.
 """
 
 import ssl
+import urllib.error
 
 import pytest
 from unittest.mock import patch, MagicMock
@@ -267,6 +268,85 @@ class TestSecureClientVerificationFailures:
 
         with pytest.raises(Exception, match="Verification failed"):
             client.make_request(req)
+
+
+class TestMakeRequestReverification:
+    """Tests that make_request() correctly handles reverification on cert rotation."""
+
+    def _make_verified_client(self):
+        """Create a SecureClient with a fake ground_truth already set."""
+        client = SecureClient(enclave="test.enclave.sh", repo="test/repo")
+        ground_truth = MagicMock()
+        ground_truth.public_key = "a" * 64
+        client._ground_truth = ground_truth
+        return client
+
+    @patch('tinfoil.client.SecureClient.reverify')
+    @patch('tinfoil.client.SecureClient._send_request')
+    def test_reverifies_and_retries_on_fingerprint_mismatch(self, mock_send, mock_reverify):
+        """On ValueError (fingerprint mismatch), must reverify and retry once."""
+        import urllib.request
+
+        expected_response = MagicMock()
+        mock_send.side_effect = [
+            ValueError("Certificate fingerprint mismatch"),
+            expected_response,
+        ]
+
+        client = self._make_verified_client()
+        req = urllib.request.Request("https://test.enclave.sh/api")
+        result = client.make_request(req)
+
+        mock_reverify.assert_called_once()
+        assert mock_send.call_count == 2
+        assert result is expected_response
+
+    @patch('tinfoil.client.SecureClient.reverify')
+    @patch('tinfoil.client.SecureClient._send_request')
+    def test_raises_original_error_if_reverify_fails(self, mock_send, mock_reverify):
+        """If reverification itself fails, the original error must be raised."""
+        import urllib.request
+
+        mock_send.side_effect = ValueError("Certificate fingerprint mismatch")
+        mock_reverify.side_effect = Exception("Attestation failed")
+
+        client = self._make_verified_client()
+        req = urllib.request.Request("https://test.enclave.sh/api")
+
+        with pytest.raises(ValueError, match="Certificate fingerprint mismatch"):
+            client.make_request(req)
+
+    @patch('tinfoil.client.SecureClient.reverify')
+    @patch('tinfoil.client.SecureClient._send_request')
+    def test_does_not_reverify_on_non_valueerror(self, mock_send, mock_reverify):
+        """Non-ValueError errors must propagate without reverification."""
+        import urllib.request
+
+        mock_send.side_effect = urllib.error.URLError("connection refused")
+
+        client = self._make_verified_client()
+        req = urllib.request.Request("https://test.enclave.sh/api")
+
+        with pytest.raises(urllib.error.URLError):
+            client.make_request(req)
+
+        mock_reverify.assert_not_called()
+
+    @patch('tinfoil.client.SecureClient.reverify')
+    @patch('tinfoil.client.SecureClient._send_request')
+    def test_does_not_reverify_on_oserror(self, mock_send, mock_reverify):
+        """OSError must propagate without reverification."""
+        import urllib.request
+
+        mock_send.side_effect = OSError("network unreachable")
+
+        client = self._make_verified_client()
+        req = urllib.request.Request("https://test.enclave.sh/api")
+
+        with pytest.raises(OSError):
+            client.make_request(req)
+
+        mock_reverify.assert_not_called()
 
 
 class TestDirectMeasurementVerification:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automatically re-verifies enclave attestation on TLS certificate rotation and retries the request once to reduce downtime.

- **New Features**
  - Added `reverify()` to force attestation refresh. For httpx clients, call it and then recreate the client via `make_secure_http_client()` or `make_secure_async_http_client()`.
  - `make_request` now retries once after re-attestation only on certificate fingerprint mismatch. If re-verification fails, the original error is raised. Other errors propagate without re-attesting.

- **Refactors**
  - Extracted `_send_request()` for a single attempt using the current pinned client.

<sup>Written for commit b18034b6ecff609957d7a966f8b302e4cd72b22f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

