### PR TITLE
chore: bump release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = ["tinfoil", "tinfoil.attestation"]
 
 [project]
 name = "tinfoil"
-version = "0.11.0"
+version = "0.11.1"
 description = "Python client for Tinfoil"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare 0.11.1 patch release of `tinfoil`. Updates `pyproject.toml` version from 0.11.0 to 0.11.1 for publishing.

<sup>Written for commit 1e94576695321ff2d1090e9a6ce13093123af7d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

