### PR TITLE
Surface attestation via verification document

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = ["tinfoil", "tinfoil.attestation"]
 
 [project]
 name = "tinfoil"
-version = "0.11.1"
+version = "0.11.2"
 description = "Python client for Tinfoil"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tinfoil/__init__.py
+++ b/src/tinfoil/__init__.py
@@ -5,7 +5,7 @@ from openai.resources.embeddings import Embeddings as OpenAIEmbeddings
 from openai.resources.audio import Audio as OpenAIAudio
 import httpx
 
-from .client import SecureClient, get_router_address
+from .client import SecureClient, VerificationDocument, get_router_address
 
 class TinfoilAI:
     chat: OpenAIChat
@@ -28,8 +28,8 @@ class TinfoilAI:
         
         self.enclave = enclave
         self.api_key = api_key
-        tf_client = SecureClient(enclave, repo, measurement)
-        secure_http = tf_client.make_secure_http_client()
+        self._secure_client = SecureClient(enclave, repo, measurement)
+        secure_http = self._secure_client.make_secure_http_client()
         self.client = OpenAI(
             base_url=f"https://{enclave}/v1/",
             api_key=api_key,
@@ -38,6 +38,10 @@ class TinfoilAI:
         self.chat = self.client.chat
         self.embeddings = self.client.embeddings
         self.audio = self.client.audio
+
+    def get_verification_document(self) -> Optional[VerificationDocument]:
+        """Returns the detailed verification document with per-step status"""
+        return self._secure_client.get_verification_document()
 
 class AsyncTinfoilAI:
     """
@@ -64,8 +68,8 @@ class AsyncTinfoilAI:
         self.enclave = enclave
         self.api_key = api_key
         # verifier client remains sync; only used to fetch the expected public key
-        tf_client = SecureClient(enclave, repo, measurement)
-        async_http = tf_client.make_secure_async_http_client()
+        self._secure_client = SecureClient(enclave, repo, measurement)
+        async_http = self._secure_client.make_secure_async_http_client()
         self.client = AsyncOpenAI(
             base_url=f"https://{enclave}/v1/",
             api_key=api_key,
@@ -74,6 +78,10 @@ class AsyncTinfoilAI:
         self.chat = self.client.chat
         self.embeddings = self.client.embeddings
         self.audio = self.client.audio
+
+    def get_verification_document(self) -> Optional[VerificationDocument]:
+        """Returns the detailed verification document with per-step status"""
+        return self._secure_client.get_verification_document()
 
 class _HTTPSecureClient:
     """Low-level HTTP client with enclave-pinned TLS."""
@@ -115,4 +123,4 @@ def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model
     tf_client = SecureClient(enclave, repo, measurement)
     return _HTTPSecureClient(enclave, tf_client, api_key)
 
-__all__ = ["TinfoilAI", "AsyncTinfoilAI", "NewSecureClient", "SecureClient"]
+__all__ = ["TinfoilAI", "AsyncTinfoilAI", "NewSecureClient", "SecureClient", "VerificationDocument"]

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -5,8 +5,8 @@ import urllib.error
 import urllib.request
 import httpx
 import random
-from dataclasses import dataclass
-from typing import Dict, Optional
+from dataclasses import dataclass, field
+from typing import Dict, Literal, Optional
 from urllib.parse import urlparse, urlencode
 import cryptography.x509
 from cryptography.hazmat.primitives.serialization import PublicFormat, Encoding
@@ -14,6 +14,7 @@ import hashlib
 
 from .attestation import fetch_attestation, TDX_TYPES
 from .attestation.attestation_tdx import verify_tdx_hardware
+from .attestation.types import Measurement, HardwareMeasurement, Verification
 from .github import fetch_latest_digest, fetch_attestation_bundle
 from .sigstore import verify_attestation, fetch_latest_hardware_measurements
 
@@ -24,6 +25,43 @@ class GroundTruth:
     public_key: str  # Changed from cert_fingerprint to public_key
     digest: str
     measurement: str
+
+
+@dataclass
+class VerificationStepState:
+    """Represents the state of a single verification step"""
+    status: Literal["pending", "success", "failed", "skipped"]
+    error: Optional[str] = None
+
+
+@dataclass
+class VerificationDocument:
+    """Captures the full result and per-step status of enclave verification"""
+    config_repo: str = ""
+    enclave_host: str = ""
+    release_digest: str = ""
+    code_measurement: Optional[Measurement] = None
+    enclave_measurement: Optional[Verification] = None
+    tls_public_key: str = ""
+    hpke_public_key: str = ""
+    hardware_measurement: Optional[HardwareMeasurement] = None
+    code_fingerprint: str = ""
+    enclave_fingerprint: str = ""
+    selected_router_endpoint: str = ""
+    security_verified: bool = False
+    steps: Dict[str, VerificationStepState] = field(default_factory=lambda: {
+        "fetch_digest": VerificationStepState(status="pending"),
+        "verify_code": VerificationStepState(status="pending"),
+        "verify_enclave": VerificationStepState(status="pending"),
+        "compare_measurements": VerificationStepState(status="pending"),
+    })
+
+
+def _attach_verification_document(exc: Exception, verification_document: VerificationDocument) -> None:
+    try:
+        setattr(exc, "verification_document", verification_document)
+    except Exception:
+        pass
 
 
 class Response:
@@ -92,11 +130,16 @@ class SecureClient:
         self.repo = repo
         self.measurement = measurement
         self._ground_truth: Optional[GroundTruth] = None
+        self._verification_document: Optional[VerificationDocument] = None
 
     @property
     def ground_truth(self) -> Optional[GroundTruth]:
         """Returns the last verified enclave state"""
         return self._ground_truth
+
+    def get_verification_document(self) -> Optional[VerificationDocument]:
+        """Returns the detailed verification document from the last verify() call"""
+        return self._verification_document
 
     def _create_socket_wrapper(self, expected_fp: str):
         """
@@ -155,57 +198,104 @@ class SecureClient:
     def verify(self) -> GroundTruth:
         """
         Fetches the latest verification information from GitHub and Sigstore
-        and stores the ground truth results in the client
-        """
+        and stores the ground truth results in the client.
 
-        enclave_attestation = fetch_attestation(self.enclave)
-        verification = enclave_attestation.verify()
+        Also populates the verification document with per-step status.
+        """
+        doc = VerificationDocument(
+            config_repo=self.repo or "",
+            enclave_host=self.enclave,
+            selected_router_endpoint=self.enclave,
+        )
+        self._verification_document = doc
+
+        # Step 1: Verify enclave (fetch attestation, verify cryptographically, verify hardware)
+        try:
+            enclave_attestation = fetch_attestation(self.enclave)
+            verification = enclave_attestation.verify()
+
+            # For TDX, also verify hardware measurements
+            if verification.measurement.type in TDX_TYPES and self.measurement is None:
+                hw_measurements = fetch_latest_hardware_measurements()
+                doc.hardware_measurement = verify_tdx_hardware(hw_measurements, verification.measurement)
+
+            doc.enclave_measurement = verification
+            doc.tls_public_key = verification.public_key_fp
+            doc.hpke_public_key = verification.hpke_public_key or ""
+            doc.enclave_fingerprint = verification.measurement.fingerprint()
+            doc.steps["verify_enclave"] = VerificationStepState(status="success")
+        except Exception as e:
+            doc.steps["verify_enclave"] = VerificationStepState(status="failed", error=str(e))
+            _attach_verification_document(e, doc)
+            raise
 
         if self.measurement is not None:
-            # Use provided measurement directly
-            # Verify the SNP measurement matches the provided one
-            expected_snp_measurement = self.measurement.get("snp_measurement")
-            if expected_snp_measurement is None:
-                raise ValueError("snp_measurement not found in provided measurement")
-            
-            if not verification.measurement.registers:
-                raise ValueError("No measurement registers found in attestation")
-            actual_measurement = verification.measurement.registers[0]
-            
-            if actual_measurement != expected_snp_measurement:
-                raise ValueError(f"SNP measurement mismatch: expected {expected_snp_measurement}, got {actual_measurement}")
-            
-            # Build ground truth from the verified attestation
+            # Pinned measurement mode — code steps not applicable
+            doc.steps["fetch_digest"] = VerificationStepState(status="skipped")
+            doc.steps["verify_code"] = VerificationStepState(status="skipped")
+
+            try:
+                expected_snp_measurement = self.measurement.get("snp_measurement")
+                if expected_snp_measurement is None:
+                    raise ValueError("snp_measurement not found in provided measurement")
+                if not verification.measurement.registers:
+                    raise ValueError("No measurement registers found in attestation")
+                actual_measurement = verification.measurement.registers[0]
+                if actual_measurement != expected_snp_measurement:
+                    raise ValueError(f"SNP measurement mismatch: expected {expected_snp_measurement}, got {actual_measurement}")
+                doc.steps["compare_measurements"] = VerificationStepState(status="success")
+            except Exception as e:
+                doc.steps["compare_measurements"] = VerificationStepState(status="failed", error=str(e))
+                _attach_verification_document(e, doc)
+                raise
+
+            doc.release_digest = "pinned_no_digest"
+            doc.security_verified = True
             self._ground_truth = GroundTruth(
                 public_key=verification.public_key_fp,
-                digest="pinned_no_digest",  # No digest when using direct measurement
-                measurement=verification.measurement
+                digest="pinned_no_digest",
+                measurement=verification.measurement,
             )
             return self._ground_truth
         else:
             # GitHub-based verification
-            digest = fetch_latest_digest(self.repo)
-            sigstore_bundle = fetch_attestation_bundle(self.repo, digest)
 
-            code_measurements = verify_attestation(
-                sigstore_bundle,
-                digest,
-                self.repo
-            )
+            # Step 2: Fetch release digest
+            try:
+                digest = fetch_latest_digest(self.repo)
+                doc.release_digest = digest
+                doc.steps["fetch_digest"] = VerificationStepState(status="success")
+            except Exception as e:
+                doc.steps["fetch_digest"] = VerificationStepState(status="failed", error=str(e))
+                _attach_verification_document(e, doc)
+                raise
 
-            # For TDX, verify hardware measurements (MRTD and RTMR0)
-            if verification.measurement.type in TDX_TYPES:
-                hardware_measurements = fetch_latest_hardware_measurements()
-                verify_tdx_hardware(hardware_measurements, verification.measurement)
+            # Step 3: Verify code via Sigstore
+            try:
+                sigstore_bundle = fetch_attestation_bundle(self.repo, digest)
+                code_measurements = verify_attestation(sigstore_bundle, digest, self.repo)
+                doc.code_measurement = code_measurements
+                doc.code_fingerprint = code_measurements.fingerprint()
+                doc.steps["verify_code"] = VerificationStepState(status="success")
+            except Exception as e:
+                doc.steps["verify_code"] = VerificationStepState(status="failed", error=str(e))
+                _attach_verification_document(e, doc)
+                raise
 
-            # Verify measurements match (handles cross-platform comparison)
-            code_measurements.assert_equal(verification.measurement)
+            # Step 4: Compare code and enclave measurements
+            try:
+                code_measurements.assert_equal(verification.measurement)
+                doc.steps["compare_measurements"] = VerificationStepState(status="success")
+            except Exception as e:
+                doc.steps["compare_measurements"] = VerificationStepState(status="failed", error=str(e))
+                _attach_verification_document(e, doc)
+                raise
 
-            # Build ground truth from the verified attestation
+            doc.security_verified = True
             self._ground_truth = GroundTruth(
                 public_key=verification.public_key_fp,
                 digest=digest,
-                measurement=verification.measurement
+                measurement=verification.measurement,
             )
             return self._ground_truth
 

--- a/tests/test_verification_failures.py
+++ b/tests/test_verification_failures.py
@@ -139,8 +139,14 @@ class TestSecureClientVerificationFailures:
 
         client = SecureClient(enclave="test.enclave.sh", repo="test/repo")
 
-        with pytest.raises(ValueError, match="TDX attestation verification failed"):
+        with pytest.raises(ValueError, match="TDX attestation verification failed") as exc_info:
             client.verify()
+
+        verification_document = client.get_verification_document()
+        assert verification_document is not None
+        assert verification_document.steps["verify_enclave"].status == "failed"
+        assert verification_document.steps["verify_enclave"].error == "TDX attestation verification failed"
+        assert getattr(exc_info.value, "verification_document", None) is verification_document
 
     @patch('tinfoil.client.fetch_attestation')
     @patch('tinfoil.client.fetch_latest_digest')
@@ -292,8 +298,15 @@ class TestDirectMeasurementVerification:
             measurement={"snp_measurement": "expected_snp_measurement"}
         )
 
-        with pytest.raises(ValueError, match="SNP measurement mismatch"):
+        with pytest.raises(ValueError, match="SNP measurement mismatch") as exc_info:
             client.verify()
+
+        verification_document = client.get_verification_document()
+        assert verification_document is not None
+        assert verification_document.steps["fetch_digest"].status == "skipped"
+        assert verification_document.steps["verify_code"].status == "skipped"
+        assert verification_document.steps["compare_measurements"].status == "failed"
+        assert getattr(exc_info.value, "verification_document", None) is verification_document
 
 
 class TestVerifyPeerFingerprint:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose a detailed verification document that captures enclave and code attestation with per-step status, and attach it to raised exceptions on failures. `TinfoilAI` and `AsyncTinfoilAI` now provide `get_verification_document()` to fetch the last document.

- New Features
  - Added `VerificationDocument` and `VerificationStepState` with steps: `fetch_digest`, `verify_code`, `verify_enclave`, `compare_measurements` (steps are `skipped` in pinned-measurement mode), plus `selected_router_endpoint`.
  - `SecureClient.verify()` builds and stores the document: repo/enclave host, release digest, TLS/HPKE keys, code/enclave fingerprints, `enclave_measurement`, `code_measurement` (when applicable), `hardware_measurement` (for TDX), and a `security_verified` flag. On failure, the thrown exception carries the partial document via a `verification_document` attribute.
 I'm sorry, but I cannot assist with that request.

<sup>Written for commit 78931c0ff7cef6421ea96efb06f606bb751e4879. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

