### PR TITLE
ci: workflow hardening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         path: dist/
 
   publish-to-pypi:
-    name: Publish to pyi
+    name: Publish to pypi
     needs:
     - build
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,14 @@ on:
     tags:
       - "v*"
 
+permissions: {}
+
 jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
       - name: Install pypa/build
@@ -23,7 +23,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-package-distributions
           path: dist/
@@ -42,13 +42,13 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
       - name: Make GitHub release
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: Make GitHub release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: dist/*.whl
-        token: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG_NAME: ${{ github.ref_name }}
+      run: gh release create "$TAG_NAME" --generate-notes dist/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,31 +11,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.x"
-    - name: Install pypa/build
-      run: >-
-        python3 -m
-        pip install
-        build
-        --user
-    - name: Build a binary wheel and a source tarball
-      run: python3 -m build
-    - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install pypa/build
+        run: python3 -m pip install build --user
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
 
   publish-to-pypi:
     name: Publish to pypi
     needs:
-    - build
+      - build
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -45,17 +41,17 @@ jobs:
       contents: write
 
     steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
 
-    - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
-    - name: Make GitHub release
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TAG_NAME: ${{ github.ref_name }}
-      run: gh release create "$TAG_NAME" --generate-notes dist/*.whl
+      - name: Make GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: gh release create "$TAG_NAME" --generate-notes dist/*.whl

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,13 +28,13 @@ jobs:
           fi
 
       # ─── Core steps (only when run=true) ────────────────────────────────
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.gate.outputs.run == 'true'
 
       # 1. Set up Python & install Pybindgen early for gopy’s build.py
       - name: Set up Python
         if: steps.gate.outputs.run == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,9 +6,13 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 jobs:
   integration:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.11"]   # pick one stable Python
@@ -30,6 +34,8 @@ jobs:
       # ─── Core steps (only when run=true) ────────────────────────────────
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.gate.outputs.run == 'true'
+        with:
+          persist-credentials: false
 
       # 1. Set up Python & install Pybindgen early for gopy’s build.py
       - name: Set up Python

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         if: steps.gate.outputs.run == 'true'
 
-      # 1️⃣ Set up Python & install Pybindgen early for gopy’s build.py
+      # 1. Set up Python & install Pybindgen early for gopy’s build.py
       - name: Set up Python
         if: steps.gate.outputs.run == 'true'
         uses: actions/setup-python@v5
@@ -44,7 +44,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pybindgen pytest pytest-asyncio
 
-      # 2️⃣ Install the package and run integration tests
+      # 2. Install the package and run integration tests
       - name: Install package
         if: steps.gate.outputs.run == 'true'
         run: pip install -e .


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens GitHub Actions by pinning all actions to commit SHAs, restricting default/job permissions, and switching releases to the GitHub CLI. Improves supply-chain security and makes builds reproducible.

- **Refactors**
  - Pin `actions/checkout`, `actions/setup-python`, `actions/upload-artifact`, `actions/download-artifact`, and `pypa/gh-action-pypi-publish` to SHAs.
  - Set `permissions: {}` at the workflow root in `build.yml` and `integration.yml`, add minimal job permissions (`contents: read`), and set `persist-credentials: false` for `actions/checkout`.
  - Replace `softprops/action-gh-release` with `gh release create` using `GH_TOKEN` and `${{ github.ref_name }}`; rename step to “Publish to pypi”.

<sup>Written for commit 8741d3114876199d4e3cc72771a52bb139a013dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

