### PR TITLE
Fix broken integration tests and enable all tests on CI

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -1,4 +1,4 @@
-name: Build and Publish
+name: SDK Release
 
 on:
   push:

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -38,5 +38,8 @@ jobs:
       - name: Install package
         run: pip install -e .
 
+      - name: Run unit tests
+        run: pytest -m "not integration"
+
       - name: Run integration tests
-        run: pytest -q -m integration
+        run: pytest -m "integration"

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -21,40 +21,22 @@ jobs:
       TINFOIL_API_KEY: ${{ secrets.TINFOIL_API_KEY }}
 
     steps:
-      # ─── Gate: skip entire job if secrets aren't set (e.g. forks) ────────
-      - name: Check integration secrets
-        id: gate
-        run: |
-          if [ -z "$TINFOIL_API_KEY" ]; then
-            echo "run=false" >> $GITHUB_OUTPUT
-          else
-            echo "run=true"  >> $GITHUB_OUTPUT
-          fi
-
-      # ─── Core steps (only when run=true) ────────────────────────────────
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        if: steps.gate.outputs.run == 'true'
         with:
           persist-credentials: false
 
-      # 1. Set up Python & install Pybindgen early for gopy’s build.py
       - name: Set up Python
-        if: steps.gate.outputs.run == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Python dependencies
-        if: steps.gate.outputs.run == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install pybindgen pytest pytest-asyncio
 
-      # 2. Install the package and run integration tests
       - name: Install package
-        if: steps.gate.outputs.run == 'true'
         run: pip install -e .
 
       - name: Run integration tests
-        if: steps.gate.outputs.run == 'true'
         run: pytest -q -m integration

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -1,4 +1,4 @@
-name: Integration
+name: SDK Test
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
 permissions: {}
 
 jobs:
-  integration:
+  test:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -17,9 +17,6 @@ jobs:
       matrix:
         python-version: ["3.11"]   # pick one stable Python
 
-    env:
-      TINFOIL_API_KEY: ${{ secrets.TINFOIL_API_KEY }}
-
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -42,4 +39,6 @@ jobs:
         run: pytest -m "not integration"
 
       - name: Run integration tests
+        env:
+          TINFOIL_API_KEY: ${{ secrets.TINFOIL_API_KEY }}
         run: pytest -m "integration"

--- a/README.md
+++ b/README.md
@@ -93,13 +93,13 @@ You can also perform arbitrary GET/POST requests that are verified:
 import os
 from tinfoil import NewSecureClient
 
-tfclient = NewSecureClient(
-    api_key=os.getenv("TINFOIL_API_KEY"),
-)
+api_key = os.getenv("TINFOIL_API_KEY")
+tfclient = NewSecureClient()
 
 # GET example
 resp = tfclient.get(
     "https://example.com/health",
+    headers={"Authorization": f"Bearer {api_key}"},
     params={"query": "value"},
     timeout=30,
 )
@@ -109,7 +109,10 @@ print(resp.status_code, resp.text)
 payload = {"key": "value"}
 resp = tfclient.post(
     "https://example.com/analyze",
-    headers={"Content-Type": "application/json"},
+    headers={
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    },
     json=payload,
     timeout=30,
 )

--- a/src/tinfoil/__init__.py
+++ b/src/tinfoil/__init__.py
@@ -85,11 +85,10 @@ class AsyncTinfoilAI:
 
 class _HTTPSecureClient:
     """Low-level HTTP client with enclave-pinned TLS."""
-    def __init__(self, enclave: str, tf_client: SecureClient, api_key: str):
+    def __init__(self, enclave: str, tf_client: SecureClient):
         self.enclave = enclave
         self._tf_client = tf_client
         self._http_client = tf_client.make_secure_http_client()
-        self._api_key = api_key
 
     def get(self, url: str, headers: Optional[dict] = None, params: Optional[dict] = None, timeout: Optional[int] = None) -> httpx.Response:
         return self._http_client.get(url, headers=headers, params=params, timeout=timeout)
@@ -105,22 +104,20 @@ class _HTTPSecureClient:
         return self._http_client.post(url, headers=headers, data=data, json=json, timeout=timeout)
 
 
-def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", api_key: str = "tinfoil", measurement: Optional[dict] = None):
-    """
-    Create a secure HTTP client for direct GET/POST through the Tinfoil enclave.
-    """
+def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", measurement: Optional[dict] = None):
+    """Create a secure HTTP client for direct GET/POST through the Tinfoil enclave."""
     if measurement is not None:
         repo = ""
-    
+
     # Ensure at least one verification method is provided
     if measurement is None and (repo == "" or repo is None):
         raise ValueError("Must provide either 'measurement' or 'repo' parameter for verification.")
-    
+
     # If enclave is empty, fetch a random one from the routers API
     if enclave == "" or enclave is None:
         enclave = get_router_address()
-    
+
     tf_client = SecureClient(enclave, repo, measurement)
-    return _HTTPSecureClient(enclave, tf_client, api_key)
+    return _HTTPSecureClient(enclave, tf_client)
 
 __all__ = ["TinfoilAI", "AsyncTinfoilAI", "NewSecureClient", "SecureClient", "VerificationDocument"]

--- a/tests/test_integration_audio.py
+++ b/tests/test_integration_audio.py
@@ -12,6 +12,8 @@ from tinfoil import TinfoilAI, AsyncTinfoilAI
 TEST_AUDIO_PATH = Path(__file__).parent / "jackhammer.wav"
 TEST_AUDIO_TEXT = "The stale smell of old beer lingers."
 
+pytestmark = pytest.mark.integration
+
 @pytest.fixture(scope="session")
 def client() -> TinfoilAI:
     return TinfoilAI(

--- a/tests/test_integration_doc.py
+++ b/tests/test_integration_doc.py
@@ -2,6 +2,10 @@ import os
 import pytest
 from tinfoil import SecureClient
 
+API_KEY = os.getenv("TINFOIL_API_KEY", "tinfoil")
+
+pytestmark = pytest.mark.integration
+
 @pytest.fixture(scope="session")
 def client() -> SecureClient:
     return SecureClient()
@@ -14,6 +18,7 @@ def test_doc_upload(client):
         response = httpx_client.post(
             f"https://{client.enclave}/v1/convert/file",
             files={'files': file},
+            headers={"Authorization": f"Bearer {API_KEY}"},
             timeout=30,
         )
         assert response.status_code == 200
@@ -28,6 +33,7 @@ async def test_doc_upload_async(client):
         response = await httpx_client.post(
             f"https://{client.enclave}/v1/convert/file",
             files={'files': file},
+            headers={"Authorization": f"Bearer {API_KEY}"},
             timeout=30,
         )
         assert response.status_code == 200

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -7,7 +7,7 @@ API_KEY = os.getenv("TINFOIL_API_KEY", "tinfoil")
 pytestmark = pytest.mark.integration
 
 def test_http_integration():
-    client = NewSecureClient(api_key=API_KEY)
+    client = NewSecureClient()
 
     url = f"https://{client.enclave}/v1/chat/completions"
     headers = {"Authorization": f"Bearer {API_KEY}"}


### PR DESCRIPTION
Several stacked issues addressed in this PR:
- SecureClient was not injecting the API key into any requests. I removed the argument to be consistent with the Go client. Users can inject the API key as needed.
- The docs and audio integration tests did not inject they api key (presumably because they expected the SecureClient to handle that). Fixed by adding the API key manually via the header
- Those integration tests were missing the integration marker and so were not being tested by CI. The marker has been added now.
- Only integration tests were being run in CI. A new step now runs all the non-integration tests first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken integration tests and updates CI to run both unit and integration tests on every PR and push. Removes the unused `api_key` parameter from `NewSecureClient` and updates examples/tests to send the API key via headers.

- **Bug Fixes**
  - Removed `api_key` from `NewSecureClient` and stopped implicit key injection to match the Go client.
  - Marked audio and docs tests with the `integration` marker and added `Authorization` headers where required.
  - Replaced the integration-only workflow with `SDK Test` (unit first, then integration), scoped `TINFOIL_API_KEY` to the integration step, and renamed the release workflow.

- **Migration**
  - When using `NewSecureClient`, include your API key explicitly in request headers for authenticated endpoints (e.g., Authorization: Bearer <key>).

<sup>Written for commit c35e39b0124abe6525f74a54658a6178fb3f811f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

