### PR TITLE
ci: add zizmor analyzer for Github Actions

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: zizmor - GitHub Actions security analysis
+
+on:
+  push:
+    branches: ["main"]
+    paths: [".github/workflows/**"]
+  pull_request:
+    branches: ["**"]
+    paths: [".github/workflows/**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a CI workflow to scan GitHub Actions files with `zizmorcore/zizmor-action` and catch insecure patterns early. Triggers on pushes to `main` and on PRs that change `.github/workflows`.

- **New Features**
  - Pins `actions/checkout@de0fac2…` (v6.0.2) with `persist-credentials: false`.
  - Pins `zizmorcore/zizmor-action@b1d7e1…` (v0.5.3) with `advanced-security: false` (no GHAS required).
  - Sets `permissions: {}` to follow least privilege.

<sup>Written for commit 14a1da0bdd2ea9ec791d6fa7f75d8b2db817ce24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

