### PR TITLE
ci: add dependency vulnerability audit

### DIFF
--- a/.github/workflows/uv-audit.yml
+++ b/.github/workflows/uv-audit.yml
@@ -1,0 +1,32 @@
+name: uv audit
+
+on:
+  workflow_dispatch:
+
+  # The actor associated with the schedule trigger will be the user who last
+  # modified the cron line below or who re-enables the workflow.
+  # See the following resources for more details:
+  # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#actor-for-scheduled-workflows
+  # https://docs.github.com/en/actions/concepts/workflows-and-actions/notifications-for-workflow-runs
+  schedule: # daily at 10:55 UTC
+    - cron: "55 10 * * *"
+
+permissions: {}
+
+jobs:
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Audit dependencies
+        run: uv audit

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ resp = tfclient.post(
 print(resp.status_code, resp.text)
 ```
 
+## Security
+
+Please report security vulnerabilities by emailing [security@tinfoil.sh](mailto:security@tinfoil.sh).
+
+We aim to respond to (legitimate) security reports within 24 hours.
+
 ## Development
 
 Install [uv](https://docs.astral.sh/uv/getting-started/installation/) before following these instructions.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a daily GitHub Actions workflow to run `uv audit` for dependency vulnerability checks and updates the README with a clear security contact path. This helps catch issues early and tells users how to report them.

- **New Features**
  - New workflow `.github/workflows/uv-audit.yml` runs `uv audit` daily at 10:55 UTC and via `workflow_dispatch`.
  - Uses pinned `actions/checkout` and `astral-sh/setup-uv`; sets `permissions: {}` with job-level `contents: read`; no persisted credentials.
  - README: adds a Security section with `security@tinfoil.sh` and a 24-hour response target.

<sup>Written for commit e779c9c06a1dc5d676ec0b7e81002a190b5d19cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

