### PR TITLE
DROP: test pypi publishing

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -2,8 +2,8 @@ name: SDK Release
 
 on:
   push:
-    tags:
-      - "v*"
+    # tags:
+    #   - "v*"
 
 permissions: {}
 
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/tinfoil
+      url: https://test.pypi.org/p/tinfoil
     permissions:
       id-token: write
       contents: write
@@ -51,6 +51,8 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
 
       - name: Make GitHub release
         env:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Publish the `tinfoil` SDK to TestPyPI instead of PyPI to validate the release pipeline. Tag-based triggers are disabled, the environment link points to https://test.pypi.org/p/tinfoil, and the publish step now uses `repository-url: https://test.pypi.org/legacy/`.

<sup>Written for commit a8d97974fb2c0947f82bd775b4d0e7218a3e3fff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

