### PR TITLE
ci: generate SBOM and include it in the wheel

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -8,8 +8,8 @@ on:
 permissions: {}
 
 jobs:
-  build:
-    name: Build distribution
+  generate-sbom:
+    name: Generate SBOM
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -22,6 +22,35 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: false
+      - name: Generate SBOM
+        run: |
+          uv sync --locked --no-dev
+          uvx --from cyclonedx-bom==7.3.0 cyclonedx-py environment --output-format json -o sbom.cdx.json
+      - name: Upload SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom
+          path: sbom.cdx.json
+
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    needs: generate-sbom
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+      - name: Download generated SBOM
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sbom
       - name: Build a binary wheel and a source tarball
         run: uv build
       - name: Store the distribution packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.28.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/tinfoil"]
+sbom-files = ["sbom.cdx.json"]
 
 [project]
 name = "tinfoil"

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "properties": [
+      {
+        "name": "placeholder",
+        "value": "This is a placeholder file to satisfy the hatchling build backend. The real SBOM is populated in the release flow."
+      }
+    ]
+  },
+  "components": []
+}


### PR DESCRIPTION
This commit adds machinery to generate a CycloneDX SBOM file during the release flow. This file is automatically included in the built wheel by hatchling as specified in PEP 770. There is a placeholder SBOM file in the root directory to satisfy hatchling when building outside the release flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generates a CycloneDX SBOM during the release flow and bundles it into the wheel per PEP 770. Adds CI steps and `hatchling` config, with a placeholder SBOM for non-release builds.

- **New Features**
  - New `Generate SBOM` job in `.github/workflows/sdk-release.yml` using `uv`/`uvx` and `cyclonedx-bom==7.3.0` to create `sbom.cdx.json`.
  - SBOM is uploaded as an artifact and downloaded in the build job; build depends on SBOM generation.
  - `pyproject.toml` sets `sbom-files = ["sbom.cdx.json"]` and requires `hatchling>=1.28.0` so the wheel includes the SBOM (PEP 770).
  - Adds a placeholder `sbom.cdx.json` to keep local and non-release builds working.

<sup>Written for commit 50fb7b106937013e462f82e041864bd85d66329a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

