### PR TITLE
chore: bump version to 0.11.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ sbom-files = ["sbom.cdx.json"]
 
 [project]
 name = "tinfoil"
-version = "0.11.2"
+version = "0.11.3"
 description = "Python client for Tinfoil"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -943,7 +943,7 @@ wheels = [
 
 [[package]]
 name = "tinfoil"
-version = "0.11.2"
+version = "0.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Bump the package version from `0.11.2` to `0.11.3` after merging the constructor timeout compatibility fix in #83.

This keeps the lockfile version in sync with `pyproject.toml`.

## Verification
- `uv run --python 3.11 python - <<'PY'\nimport tomllib\nwith open(\pyproject.toml\, \rb\) as f:\n    print(tomllib.load(f)[\project\][\version\])\nPY`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `tinfoil` to 0.11.3 to release the constructor timeout compatibility fix. Updates `pyproject.toml` and `uv.lock` to the new version.

<sup>Written for commit 4aca31635434677714ed454f99e678408003af86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

