### PR TITLE
fix(tdx): reject duplicate JSON keys in PCS collateral parsing

### DIFF
--- a/src/tinfoil/attestation/collateral_tdx.py
+++ b/src/tinfoil/attestation/collateral_tdx.py
@@ -402,6 +402,24 @@ ECDSA_SIGNATURE_SIZE = 64       # R || S (32 + 32 bytes)
 # Parsing Functions
 # =============================================================================
 
+def _reject_duplicate_keys(pairs):
+    # Signature verification extracts the FIRST textual occurrence of a top-level
+    # key, while json.loads() keeps the LAST. A duplicate-key payload could pass
+    # signature verification over one object while validation consumes another.
+    seen = set()
+    out = {}
+    for key, value in pairs:
+        if key in seen:
+            raise CollateralError(f"Duplicate JSON key: {key!r}")
+        seen.add(key)
+        out[key] = value
+    return out
+
+
+def _strict_json_loads(response_bytes: bytes):
+    return json.loads(response_bytes, object_pairs_hook=_reject_duplicate_keys)
+
+
 def _parse_hex_bytes(hex_str: str) -> bytes:
     """Parse hex string to bytes."""
     return bytes.fromhex(hex_str)
@@ -549,7 +567,7 @@ def parse_tcb_info_response(response_bytes: bytes) -> TdxTcbInfo:
         CollateralError: If parsing fails
     """
     try:
-        data = json.loads(response_bytes)
+        data = _strict_json_loads(response_bytes)
     except json.JSONDecodeError as e:
         raise CollateralError(f"Failed to parse TCB Info JSON: {e}")
 
@@ -581,7 +599,7 @@ def parse_qe_identity_response(response_bytes: bytes) -> QeIdentity:
         CollateralError: If parsing fails
     """
     try:
-        data = json.loads(response_bytes)
+        data = _strict_json_loads(response_bytes)
     except json.JSONDecodeError as e:
         raise CollateralError(f"Failed to parse QE Identity JSON: {e}")
 
@@ -1258,7 +1276,7 @@ def _parse_tcb_eval_numbers_response(response_bytes: bytes) -> TcbEvaluationData
         CollateralError: If parsing fails
     """
     try:
-        data = json.loads(response_bytes)
+        data = _strict_json_loads(response_bytes)
     except json.JSONDecodeError as e:
         raise CollateralError(f"Failed to parse TCB evaluation data numbers JSON: {e}")
 

--- a/tests/test_collateral_tdx.py
+++ b/tests/test_collateral_tdx.py
@@ -248,6 +248,18 @@ class TestParseTcbInfoResponse:
         with pytest.raises(CollateralError, match="must be 3"):
             parse_tcb_info_response(bad_json.encode())
 
+    def test_reject_duplicate_tcb_info_key(self):
+        """Reject duplicate top-level keys: signature verification extracts the
+        first textual occurrence while json.loads keeps the last, so a duplicate
+        could pass signature check over one object while parsing another."""
+        attacker_obj = '{"id":"TDX","version":3,"fmspc":"deadbeefdead"}'
+        bad_json = (
+            '{"tcbInfo":' + attacker_obj
+            + ',' + SAMPLE_TCB_INFO_JSON.strip().lstrip('{')
+        )
+        with pytest.raises(CollateralError, match="Duplicate JSON key"):
+            parse_tcb_info_response(bad_json.encode())
+
 
 class TestParseQeIdentityResponse:
     """Test QE Identity parsing."""
@@ -274,6 +286,16 @@ class TestParseQeIdentityResponse:
         """Test that non-TD_QE ID is rejected."""
         bad_json = SAMPLE_QE_IDENTITY_JSON.replace('"id": "TD_QE"', '"id": "QE"')
         with pytest.raises(CollateralError, match="must be 'TD_QE'"):
+            parse_qe_identity_response(bad_json.encode())
+
+    def test_reject_duplicate_enclave_identity_key(self):
+        """Reject duplicate top-level keys (see TestParseTcbInfoResponse for rationale)."""
+        attacker_obj = '{"id":"TD_QE","version":2,"mrsigner":"' + ("00" * 32) + '"}'
+        bad_json = (
+            '{"enclaveIdentity":' + attacker_obj
+            + ',' + SAMPLE_QE_IDENTITY_JSON.strip().lstrip('{')
+        )
+        with pytest.raises(CollateralError, match="Duplicate JSON key"):
             parse_qe_identity_response(bad_json.encode())
 
 
@@ -1842,6 +1864,16 @@ class TestParseTcbEvalNumbersResponse:
         """Test that invalid JSON raises error."""
         with pytest.raises(CollateralError, match="Failed to parse"):
             _parse_tcb_eval_numbers_response(b"not json")
+
+    def test_reject_duplicate_tcb_eval_numbers_key(self):
+        """Reject duplicate top-level keys (see TestParseTcbInfoResponse for rationale)."""
+        attacker_obj = b'{"id":"TDX","version":1,"tcbEvalNumbers":[]}'
+        bad_json = (
+            b'{"tcbEvaluationDataNumbers":' + attacker_obj
+            + b',' + SAMPLE_TCB_EVAL_NUMBERS_RESPONSE.strip().lstrip(b'{')
+        )
+        with pytest.raises(CollateralError, match="Duplicate JSON key"):
+            _parse_tcb_eval_numbers_response(bad_json)
 
 
 class TestFetchTcbEvaluationDataNumbers:


### PR DESCRIPTION
## Summary

`_verify_collateral_signature` extracts the **first** textual occurrence of a top-level key from the raw response bytes, while `json.loads()` keeps the **last** value when a key is repeated. A crafted PCS response with duplicate top-level keys could pass signature verification over a legitimate Intel-signed inner object while validation consumes attacker-chosen fields from a second duplicate object — letting an attacker forge TCB status, FMSPC, freshness numbers, or QE identity.

Reachable on `main`: `attestation.py:41` dispatches `TDX_GUEST_V2 → verify_tdx_attestation_v2 → validate_collateral`, which calls all three vulnerable parsers. Realistic attack vector is local cache poisoning of cached collateral files.

Fix: pass an `object_pairs_hook` that rejects duplicate keys at any level to all three response parsers (`parse_tcb_info_response`, `parse_qe_identity_response`, `_parse_tcb_eval_numbers_response`). Errors out before any validation runs.

## Test plan

- [x] New unit tests assert each parser raises \`CollateralError("Duplicate JSON key: ...")\` on duplicate top-level keys.
- [x] Full unit suite: \`uv run pytest -m "not integration"\` — 265 passed, 2 skipped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate JSON keys when parsing Intel PCS collateral to prevent spoofing caused by mismatched handling of repeated keys. Enforces strict JSON across TDX TCB Info, QE Identity, and TCB Evaluation Numbers, failing fast before validation.

- **Bug Fixes**
  - Added a strict JSON loader using `object_pairs_hook` that raises `CollateralError` on duplicate keys; applied to `parse_tcb_info_response`, `parse_qe_identity_response`, and `_parse_tcb_eval_numbers_response`.
  - Added unit tests to ensure each parser rejects duplicate keys; full unit suite passes.

<sup>Written for commit 120c00e116da3dbf3d1c513b672b700a65ce8f6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

