### PR TITLE
feat: auto re-verify attestation on TLS cert rotation

### DIFF
--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -1,6 +1,9 @@
+import asyncio
+import contextlib
 import http.client
 import json
 import ssl
+import threading
 import urllib.error
 import urllib.request
 import httpx
@@ -17,6 +20,23 @@ from .attestation.attestation_tdx import verify_tdx_hardware
 from .attestation.types import Measurement, HardwareMeasurement, Verification
 from .github import fetch_latest_digest, fetch_attestation_bundle
 from .sigstore import verify_attestation, fetch_latest_hardware_measurements
+
+
+_CERTIFICATE_VERIFY_ERROR_MARKERS = (
+    "certificate_verify_failed",
+    "certificate verify failed",
+)
+
+
+class _PinMismatchError(ValueError):
+    """
+    Raised when the enclave's TLS certificate fails our pin check (wrong
+    public-key fingerprint, missing cert, or no TLS connection).
+
+    Subclasses ValueError so existing callers that do `except ValueError`
+    keep working; existence as a distinct type lets `_is_certificate_error`
+    detect pin failures via `isinstance` instead of string-matching.
+    """
 
 
 @dataclass
@@ -75,14 +95,14 @@ class Response:
 def _verify_peer_fingerprint(cert_binary: Optional[bytes], expected_fp: str) -> None:
     """Verify that a certificate's public key fingerprint matches the expected value."""
     if not cert_binary:
-        raise ValueError("No certificate found")
+        raise _PinMismatchError("No certificate found")
     cert = cryptography.x509.load_der_x509_certificate(cert_binary)
     pub_der = cert.public_key().public_bytes(
         Encoding.DER, PublicFormat.SubjectPublicKeyInfo
     )
     pk_fp = hashlib.sha256(pub_der).hexdigest()
     if pk_fp != expected_fp:
-        raise ValueError(f"Certificate fingerprint mismatch: expected {expected_fp}, got {pk_fp}")
+        raise _PinMismatchError(f"Certificate fingerprint mismatch: expected {expected_fp}, got {pk_fp}")
 
 
 class TLSBoundHTTPSHandler(urllib.request.HTTPSHandler):
@@ -101,13 +121,146 @@ class TLSBoundHTTPSHandler(urllib.request.HTTPSHandler):
         conn.connect()
         
         if not conn.sock:
-            raise ValueError("No TLS connection")
+            raise _PinMismatchError("No TLS connection")
         
         _verify_peer_fingerprint(
             conn.sock.getpeercert(binary_form=True), self.expected_pubkey
         )
         
         return conn
+
+
+def _is_certificate_error(exc: BaseException) -> bool:
+    """
+    Detect whether an exception originated from TLS certificate verification,
+    including the fingerprint pin check raised by `_verify_peer_fingerprint`.
+
+    Only certificate verification and pinning failures are safe to use as a
+    re-verification signal: they happen while establishing the connection,
+    before HTTP request bytes are sent. Generic ssl.SSLError instances can occur
+    later during request/response I/O and must not be retried automatically.
+    """
+    current: Optional[BaseException] = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+
+        if isinstance(current, _PinMismatchError):
+            return True
+
+        if isinstance(current, ssl.SSLCertVerificationError):
+            return True
+
+        if isinstance(current, ssl.SSLError):
+            msg = str(current).lower()
+            if any(marker in msg for marker in _CERTIFICATE_VERIFY_ERROR_MARKERS):
+                return True
+
+        # httpx wraps low-level errors; walk the cause/context chain.
+        current = current.__cause__ or current.__context__
+    return False
+
+
+class _ReVerifyingTransport(httpx.BaseTransport):
+    """
+    Wraps an httpx transport and transparently re-verifies the enclave's
+    attestation when a TLS certificate error is encountered.
+
+    This makes long-lived `TinfoilAI` / `SecureClient` instances resilient to
+    server certificate rotation (for example, after an enclave or router
+    restart), mirroring the behaviour of the Go and JavaScript SDKs.
+    """
+
+    def __init__(self, secure_client: "SecureClient", inner: httpx.BaseTransport):
+        self._secure_client = secure_client
+        self._inner = inner
+        self._lock = threading.Lock()
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        inner = self._inner
+        try:
+            return inner.handle_request(request)
+        except Exception as exc:
+            if not _is_certificate_error(exc):
+                raise
+
+            old_inner: Optional[httpx.BaseTransport] = None
+            retry_inner: Optional[httpx.BaseTransport] = None
+            reverify_failed = False
+            with self._lock:
+                if self._inner is inner:
+                    try:
+                        retry_inner = self._secure_client._rebuild_sync_transport()
+                    except Exception:
+                        # Re-verification failed; surface the original error so
+                        # the caller sees the genuine TLS failure rather than a
+                        # confusing re-verification failure.
+                        reverify_failed = True
+                    else:
+                        old_inner = self._inner
+                        self._inner = retry_inner
+                else:
+                    retry_inner = self._inner
+
+            if reverify_failed:
+                raise
+
+            assert retry_inner is not None
+            try:
+                return retry_inner.handle_request(request)
+            finally:
+                if old_inner is not None:
+                    with contextlib.suppress(Exception):
+                        old_inner.close()
+
+    def close(self) -> None:
+        self._inner.close()
+
+
+class _AsyncReVerifyingTransport(httpx.AsyncBaseTransport):
+    """Async counterpart to :class:`_ReVerifyingTransport`."""
+
+    def __init__(self, secure_client: "SecureClient", inner: httpx.AsyncBaseTransport):
+        self._secure_client = secure_client
+        self._inner = inner
+        self._lock = asyncio.Lock()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        inner = self._inner
+        try:
+            return await inner.handle_async_request(request)
+        except Exception as exc:
+            if not _is_certificate_error(exc):
+                raise
+
+            old_inner: Optional[httpx.AsyncBaseTransport] = None
+            retry_inner: Optional[httpx.AsyncBaseTransport] = None
+            reverify_failed = False
+            async with self._lock:
+                if self._inner is inner:
+                    try:
+                        retry_inner = await self._secure_client._rebuild_async_transport()
+                    except Exception:
+                        reverify_failed = True
+                    else:
+                        old_inner = self._inner
+                        self._inner = retry_inner
+                else:
+                    retry_inner = self._inner
+
+            if reverify_failed:
+                raise
+
+            assert retry_inner is not None
+            try:
+                return await retry_inner.handle_async_request(request)
+            finally:
+                if old_inner is not None:
+                    with contextlib.suppress(Exception):
+                        await old_inner.aclose()
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
 
 
 class SecureClient:
@@ -174,26 +327,58 @@ class SecureClient:
             return ssl_object
         return pinned_wrap_bio
 
-    def make_secure_http_client(self) -> httpx.Client:
-        """
-        Build an httpx.Client that pins the enclave's TLS cert
-        """
-        expected_fp = self.verify().public_key
+    def _build_sync_ssl_context(self, expected_fp: str) -> ssl.SSLContext:
         wrap_socket = self._create_socket_wrapper(expected_fp)
-
         ctx = ssl.create_default_context()
         ctx.wrap_socket = wrap_socket
-        return httpx.Client(verify=ctx, follow_redirects=True)
+        return ctx
+
+    def _build_async_ssl_context(self, expected_fp: str) -> ssl.SSLContext:
+        ctx = ssl.create_default_context()
+        ctx.wrap_bio = self._create_bio_wrapper(ctx.wrap_bio, expected_fp)
+        return ctx
+
+    def _rebuild_sync_transport(self) -> httpx.BaseTransport:
+        """Re-run attestation and return a fresh sync httpx transport."""
+        expected_fp = self.verify().public_key
+        ctx = self._build_sync_ssl_context(expected_fp)
+        return httpx.HTTPTransport(verify=ctx)
+
+    async def _rebuild_async_transport(self) -> httpx.AsyncBaseTransport:
+        """Re-run attestation without blocking the event loop."""
+        expected_fp = (await asyncio.to_thread(self.verify)).public_key
+        ctx = self._build_async_ssl_context(expected_fp)
+        return httpx.AsyncHTTPTransport(verify=ctx)
+
+    def make_secure_http_client(self) -> httpx.Client:
+        """
+        Build an httpx.Client that pins the enclave's TLS cert.
+
+        The returned client is suitable for long-lived use: if the enclave
+        rotates its TLS certificate (for example after a server-side restart),
+        the underlying transport will automatically re-verify attestation and
+        retry the request once.
+        """
+        expected_fp = self.verify().public_key
+        ctx = self._build_sync_ssl_context(expected_fp)
+        inner = httpx.HTTPTransport(verify=ctx)
+        transport = _ReVerifyingTransport(self, inner)
+        return httpx.Client(transport=transport, follow_redirects=True)
 
     def make_secure_async_http_client(self) -> httpx.AsyncClient:
         """
-        Build an httpx.AsyncClient that pins the enclave's TLS cert
+        Build an httpx.AsyncClient that pins the enclave's TLS cert.
+
+        The returned client is suitable for long-lived use: if the enclave
+        rotates its TLS certificate (for example after a server-side restart),
+        the underlying transport will automatically re-verify attestation and
+        retry the request once.
         """
         expected_fp = self.verify().public_key
-
-        ctx = ssl.create_default_context()
-        ctx.wrap_bio = self._create_bio_wrapper(ctx.wrap_bio, expected_fp)
-        return httpx.AsyncClient(verify=ctx, follow_redirects=True)
+        ctx = self._build_async_ssl_context(expected_fp)
+        inner = httpx.AsyncHTTPTransport(verify=ctx)
+        transport = _AsyncReVerifyingTransport(self, inner)
+        return httpx.AsyncClient(transport=transport, follow_redirects=True)
 
     def verify(self) -> GroundTruth:
         """

--- a/tests/test_certificate_reverification.py
+++ b/tests/test_certificate_reverification.py
@@ -1,0 +1,304 @@
+"""
+Tests for long-lived client support: automatic re-verification of enclave
+attestation when the server's TLS certificate rotates (for example, after
+a router restart).
+"""
+
+import ssl
+import threading
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from tinfoil.client import (
+    GroundTruth,
+    SecureClient,
+    _AsyncReVerifyingTransport,
+    _PinMismatchError,
+    _ReVerifyingTransport,
+    _is_certificate_error,
+)
+
+
+class TestIsCertificateError:
+    def test_detects_pin_mismatch_error(self):
+        err = _PinMismatchError("Certificate fingerprint mismatch: expected abc, got def")
+        assert _is_certificate_error(err)
+
+    def test_detects_pin_mismatch_no_certificate(self):
+        err = _PinMismatchError("No certificate found")
+        assert _is_certificate_error(err)
+
+    def test_detects_pin_mismatch_no_tls_connection(self):
+        err = _PinMismatchError("No TLS connection")
+        assert _is_certificate_error(err)
+
+    def test_detects_ssl_cert_verification_error(self):
+        err = ssl.SSLCertVerificationError("bad cert")
+        assert _is_certificate_error(err)
+
+    def test_detects_certificate_verify_failed_ssl_error(self):
+        err = ssl.SSLError("[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed")
+        assert _is_certificate_error(err)
+
+    def test_detects_through_cause_chain(self):
+        original = _PinMismatchError("Certificate fingerprint mismatch: ...")
+        wrapper = httpx.ConnectError("connection error")
+        wrapper.__cause__ = original
+        assert _is_certificate_error(wrapper)
+
+    def test_detects_through_context_chain(self):
+        original = _PinMismatchError("Certificate fingerprint mismatch: ...")
+        try:
+            try:
+                raise original
+            except _PinMismatchError:
+                raise httpx.ConnectError("wrapped")
+        except httpx.ConnectError as wrapped:
+            assert _is_certificate_error(wrapped)
+
+    def test_ignores_plain_value_error_with_matching_text(self):
+        # A plain ValueError with cert-looking text should NOT trigger
+        # re-verification — detection is type-based, not string-based.
+        err = ValueError("Certificate fingerprint mismatch: expected abc, got def")
+        assert not _is_certificate_error(err)
+
+    def test_ignores_unrelated_value_error(self):
+        err = ValueError("Something completely different")
+        assert not _is_certificate_error(err)
+
+    def test_ignores_unrelated_exception(self):
+        err = RuntimeError("Unrelated")
+        assert not _is_certificate_error(err)
+
+    def test_ignores_generic_ssl_error(self):
+        err = ssl.SSLError("unexpected eof while reading")
+        assert not _is_certificate_error(err)
+
+    def test_ignores_ssl_want_read_error(self):
+        err = ssl.SSLWantReadError()
+        assert not _is_certificate_error(err)
+
+
+def _make_request() -> httpx.Request:
+    return httpx.Request("GET", "https://example.test/")
+
+
+def _make_response() -> httpx.Response:
+    return httpx.Response(200, content=b"ok")
+
+
+class TestReVerifyingTransportSync:
+    def test_passes_through_when_no_error(self):
+        secure_client = MagicMock(spec=SecureClient)
+        inner = MagicMock(spec=httpx.BaseTransport)
+        response = _make_response()
+        inner.handle_request.return_value = response
+
+        transport = _ReVerifyingTransport(secure_client, inner)
+
+        result = transport.handle_request(_make_request())
+        assert result is response
+        secure_client._rebuild_sync_transport.assert_not_called()
+
+    def test_propagates_unrelated_errors(self):
+        secure_client = MagicMock(spec=SecureClient)
+        inner = MagicMock(spec=httpx.BaseTransport)
+        inner.handle_request.side_effect = RuntimeError("boom")
+
+        transport = _ReVerifyingTransport(secure_client, inner)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            transport.handle_request(_make_request())
+        secure_client._rebuild_sync_transport.assert_not_called()
+
+    def test_propagates_generic_ssl_errors(self):
+        secure_client = MagicMock(spec=SecureClient)
+        inner = MagicMock(spec=httpx.BaseTransport)
+        inner.handle_request.side_effect = ssl.SSLError("unexpected eof while reading")
+
+        transport = _ReVerifyingTransport(secure_client, inner)
+
+        with pytest.raises(ssl.SSLError, match="unexpected eof"):
+            transport.handle_request(_make_request())
+        secure_client._rebuild_sync_transport.assert_not_called()
+
+    def test_reverifies_and_retries_on_fingerprint_mismatch(self):
+        secure_client = MagicMock(spec=SecureClient)
+        new_inner = MagicMock(spec=httpx.BaseTransport)
+        retry_response = _make_response()
+        new_inner.handle_request.return_value = retry_response
+        secure_client._rebuild_sync_transport.return_value = new_inner
+
+        inner = MagicMock(spec=httpx.BaseTransport)
+        inner.handle_request.side_effect = _PinMismatchError(
+            "Certificate fingerprint mismatch: expected abc, got def"
+        )
+
+        transport = _ReVerifyingTransport(secure_client, inner)
+
+        result = transport.handle_request(_make_request())
+        assert result is retry_response
+        secure_client._rebuild_sync_transport.assert_called_once()
+        new_inner.handle_request.assert_called_once()
+        inner.close.assert_called_once()
+
+    def test_reverifies_through_httpx_connect_error_chain(self):
+        secure_client = MagicMock(spec=SecureClient)
+        new_inner = MagicMock(spec=httpx.BaseTransport)
+        new_inner.handle_request.return_value = _make_response()
+        secure_client._rebuild_sync_transport.return_value = new_inner
+
+        inner = MagicMock(spec=httpx.BaseTransport)
+
+        def raise_wrapped(_req):
+            try:
+                raise _PinMismatchError("Certificate fingerprint mismatch: ...")
+            except _PinMismatchError:
+                raise httpx.ConnectError("connect error")
+
+        inner.handle_request.side_effect = raise_wrapped
+
+        transport = _ReVerifyingTransport(secure_client, inner)
+        transport.handle_request(_make_request())
+        secure_client._rebuild_sync_transport.assert_called_once()
+
+    def test_raises_original_error_when_reverification_fails(self):
+        secure_client = MagicMock(spec=SecureClient)
+        secure_client._rebuild_sync_transport.side_effect = RuntimeError(
+            "verify failed"
+        )
+
+        original_err = _PinMismatchError("Certificate fingerprint mismatch: ...")
+        inner = MagicMock(spec=httpx.BaseTransport)
+        inner.handle_request.side_effect = original_err
+
+        transport = _ReVerifyingTransport(secure_client, inner)
+
+        with pytest.raises(_PinMismatchError, match="Certificate fingerprint mismatch"):
+            transport.handle_request(_make_request())
+        inner.close.assert_not_called()
+
+    def test_retries_exactly_once_when_rebuilt_transport_also_fails(self):
+        # If re-verification succeeds but the new transport also raises a cert
+        # error (e.g. the server didn't actually rotate, or rotated to a key
+        # the verifier doesn't yet see), the second error must propagate —
+        # no infinite retry loop.
+        secure_client = MagicMock(spec=SecureClient)
+        new_inner = MagicMock(spec=httpx.BaseTransport)
+        new_inner.handle_request.side_effect = _PinMismatchError(
+            "Certificate fingerprint mismatch: still wrong"
+        )
+        secure_client._rebuild_sync_transport.return_value = new_inner
+
+        inner = MagicMock(spec=httpx.BaseTransport)
+        inner.handle_request.side_effect = _PinMismatchError(
+            "Certificate fingerprint mismatch: initial"
+        )
+
+        transport = _ReVerifyingTransport(secure_client, inner)
+
+        with pytest.raises(_PinMismatchError, match="still wrong"):
+            transport.handle_request(_make_request())
+
+        secure_client._rebuild_sync_transport.assert_called_once()
+        inner.handle_request.assert_called_once()
+        new_inner.handle_request.assert_called_once()
+
+
+class TestReVerifyingTransportAsync:
+    @pytest.mark.asyncio
+    async def test_passes_through_when_no_error(self):
+        secure_client = MagicMock(spec=SecureClient)
+        inner = MagicMock(spec=httpx.AsyncBaseTransport)
+        response = _make_response()
+
+        async def ok(_req):
+            return response
+
+        inner.handle_async_request.side_effect = ok
+
+        transport = _AsyncReVerifyingTransport(secure_client, inner)
+
+        result = await transport.handle_async_request(_make_request())
+        assert result is response
+
+    @pytest.mark.asyncio
+    async def test_reverifies_and_retries_on_fingerprint_mismatch(self):
+        secure_client = MagicMock(spec=SecureClient)
+        new_inner = MagicMock(spec=httpx.AsyncBaseTransport)
+        retry_response = _make_response()
+
+        async def retry_ok(_req):
+            return retry_response
+
+        new_inner.handle_async_request.side_effect = retry_ok
+        secure_client._rebuild_async_transport.return_value = new_inner
+
+        inner = MagicMock(spec=httpx.AsyncBaseTransport)
+
+        async def fail(_req):
+            raise _PinMismatchError("Certificate fingerprint mismatch: expected abc, got def")
+
+        inner.handle_async_request.side_effect = fail
+
+        transport = _AsyncReVerifyingTransport(secure_client, inner)
+        result = await transport.handle_async_request(_make_request())
+        assert result is retry_response
+        secure_client._rebuild_async_transport.assert_awaited_once()
+        inner.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_raises_original_error_when_reverification_fails(self):
+        secure_client = MagicMock(spec=SecureClient)
+        secure_client._rebuild_async_transport.side_effect = RuntimeError(
+            "verify failed"
+        )
+
+        original_err = _PinMismatchError("Certificate fingerprint mismatch: ...")
+
+        async def fail(_req):
+            raise original_err
+
+        inner = MagicMock(spec=httpx.AsyncBaseTransport)
+        inner.handle_async_request.side_effect = fail
+
+        transport = _AsyncReVerifyingTransport(secure_client, inner)
+
+        with pytest.raises(_PinMismatchError, match="Certificate fingerprint mismatch"):
+            await transport.handle_async_request(_make_request())
+        inner.aclose.assert_not_called()
+
+
+class TestSecureClientRebuildHooks:
+    """Make sure the rebuild hooks actually re-run verify() with a fresh fingerprint."""
+
+    @patch.object(SecureClient, "verify")
+    def test_rebuild_sync_transport_calls_verify(self, mock_verify):
+        mock_verify.return_value = GroundTruth(
+            public_key="a" * 64, digest="d", measurement="m"
+        )
+        client = SecureClient(enclave="test.enclave.sh", repo="test/repo")
+        transport = client._rebuild_sync_transport()
+        assert isinstance(transport, httpx.HTTPTransport)
+        mock_verify.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch.object(SecureClient, "verify")
+    async def test_rebuild_async_transport_offloads_verify(self, mock_verify):
+        loop_thread_id = threading.get_ident()
+        verify_thread_id = None
+
+        def fake_verify():
+            nonlocal verify_thread_id
+            verify_thread_id = threading.get_ident()
+            return GroundTruth(public_key="a" * 64, digest="d", measurement="m")
+
+        mock_verify.side_effect = fake_verify
+        client = SecureClient(enclave="test.enclave.sh", repo="test/repo")
+        transport = await client._rebuild_async_transport()
+        assert isinstance(transport, httpx.AsyncHTTPTransport)
+        mock_verify.assert_called_once()
+        assert verify_thread_id is not None
+        assert verify_thread_id != loop_thread_id

--- a/tests/test_verification_failures.py
+++ b/tests/test_verification_failures.py
@@ -398,7 +398,11 @@ class TestAsyncTLSPinning:
 
     def _get_ssl_context(self, async_http_client):
         """Extract the SSL context from an httpx.AsyncClient."""
-        return async_http_client._transport._pool._ssl_context
+        transport = async_http_client._transport
+        # The transport is wrapped with _AsyncReVerifyingTransport for
+        # long-lived client support; unwrap to reach the real httpx transport.
+        inner = getattr(transport, "_inner", transport)
+        return inner._pool._ssl_context
 
     def _call_pinned_wrap_bio(self, ssl_ctx, fake_ssl_object):
         """


### PR DESCRIPTION
Long-lived TinfoilAI / AsyncTinfoilAI / SecureClient instances previously failed permanently with APIConnectionError ("Certificate fingerprint mismatch") after server-side cert rotation (e.g. router restart).

Wrap the httpx sync and async transports so a TLS pin failure triggers a single re-verification of the enclave attestation, rebuilds the SSL context against the fresh pin, and retries the request once. If re-verification itself fails, the original certificate error is re-raised so genuinely malicious connections still surface clearly.

This mirrors the existing behavior in tinfoil-go and tinfoil-js.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically re-verifies enclave attestation and refreshes the TLS pin on server cert rotation, so long‑lived `SecureClient`/`TinfoilAI` instances recover with a single retry instead of failing on fingerprint mismatch. Mirrors behavior in tinfoil-go and tinfoil-js.

- **New Features**
  - Added `_ReVerifyingTransport` and `_AsyncReVerifyingTransport` wrapping `httpx` transports: on certificate verify/pin mismatch, run `verify()`, rebuild the SSL context with the new pin, and retry once.
  - Introduced `_PinMismatchError` and `_is_certificate_error` to reliably detect certificate verification failures (walks cause/context; ignores generic `ssl.SSLError` I/O) so only safe retries occur.
  - Updated `make_secure_http_client` and `make_secure_async_http_client` to use the new wrappers; added `_rebuild_sync_transport`/`_rebuild_async_transport`; wrappers use locks to avoid duplicate re-verifies and async offloads `verify()`; if re-verification fails, the original certificate error is re-raised.

<sup>Written for commit 68e6690fbc5e10b5bba04a08bcce170e67fb8b69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

