### PR TITLE
Rename Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and Publish
+name: Release
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Integration
+name: Test
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
 permissions: {}
 
 jobs:
-  integration:
+  test:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tinfoil Python Library
 
 ![PyPI - Version](https://img.shields.io/pypi/v/tinfoil)
-[![SDK Test](https://github.com/tinfoilsh/tinfoil-python/actions/workflows/sdk-test.yml/badge.svg)](https://github.com/tinfoilsh/tinfoil-python/actions/workflows/sdk-test.yml)
+[![SDK Test](https://github.com/tinfoilsh/tinfoil-python/actions/workflows/test.yml/badge.svg)](https://github.com/tinfoilsh/tinfoil-python/actions/workflows/test.yml)
 [![Documentation](https://img.shields.io/badge/docs-tinfoil.sh-blue)](https://docs.tinfoil.sh/sdk/python-sdk)
 
 A Python client for secure AI model inference through Tinfoil.


### PR DESCRIPTION
Renames the workflows to clarify their functions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed GitHub Actions workflows for clearer names and fixed the README CI badge to match the new test workflow. This keeps the Actions list and status badge consistent.

- **Refactors**
  - `.github/workflows/release.yml`: name changed to "Release".
  - `.github/workflows/test.yml`: name changed to "Test"; job id renamed from `integration` to `test`.

- **Bug Fixes**
  - README CI badge now points to `actions/workflows/test.yml`.

<sup>Written for commit 9454eb1f8b50bccd34a63e091de38fd7e1a15939. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

