### PR TITLE
chore: bump version to 0.12.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ sbom-files = ["sbom.cdx.json"]
 
 [project]
 name = "tinfoil"
-version = "0.11.5"
+version = "0.12.1"
 description = "Python client for Tinfoil"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-05-08T18:47:31.339628Z"
+exclude-newer = "2026-05-08T19:28:06.512104Z"
 exclude-newer-span = "P4D"
 
 [[package]]
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "tinfoil"
-version = "0.11.5"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps `tinfoil` from 0.11.5 to 0.12.1 in `pyproject.toml` and `uv.lock` to keep release metadata in sync.

<sup>Written for commit c43f8c5fc7319ea1652c329fd14804463e5095ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

