### PR TITLE
Add Tinfoil conformance testing

### DIFF
--- a/.github/workflows/tinfoil-conformance.yml
+++ b/.github/workflows/tinfoil-conformance.yml
@@ -1,0 +1,78 @@
+name: Tinfoil Conformance
+
+# Runs the cross-SDK Tinfoil conformance suite
+# (https://github.com/lsd-cat/tinfoil-conformance) against this SDK's
+# `tinfoil-conformance` binary. Speaks the Tinfoil policy-layer CLI
+# contract (JSON-in / JSON-out); distinct from the test/audit workflows
+# which exercise the consumer-facing verifier API.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  conformance:
+    name: Tinfoil Conformance
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout SDK
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.11"
+
+      - name: Install tinfoil (provides the tinfoil-conformance binary)
+        run: uv sync --locked
+
+      - name: Checkout tinfoil-conformance suite
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lsd-cat/tinfoil-conformance
+          ref: main
+          path: tinfoil-conformance
+          persist-credentials: false
+
+      - name: Set up Python for the harness
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: tinfoil-conformance/harness/pyproject.toml
+
+      - name: Install harness
+        run: pip install ./tinfoil-conformance/harness
+
+      - name: Show SDK capabilities
+        run: |
+          tinfoil-conformance capabilities \
+            --sdk "tinfoil-py=uv run --no-sync tinfoil-conformance"
+
+      - name: Run conformance vectors
+        run: |
+          tinfoil-conformance run \
+            --sdk "tinfoil-py=uv run --no-sync tinfoil-conformance" \
+            --vectors tinfoil-conformance/vectors/sigstore
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: tinfoil-conformance-results
+          path: results/
+
+      - name: Append summary
+        if: always()
+        run: |
+          if [ -f results/latest/results.md ]; then
+            cat results/latest/results.md >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/tinfoil-conformance.yml
+++ b/.github/workflows/tinfoil-conformance.yml
@@ -1,7 +1,7 @@
 name: Tinfoil Conformance
 
 # Runs the cross-SDK Tinfoil conformance suite
-# (https://github.com/lsd-cat/tinfoil-conformance) against this SDK's
+# (https://github.com/tinfoilsh/tinfoil-conformance) against this SDK's
 # `tinfoil-conformance` binary. Speaks the Tinfoil policy-layer CLI
 # contract (JSON-in / JSON-out); distinct from the test/audit workflows
 # which exercise the consumer-facing verifier API.
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout tinfoil-conformance suite
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: lsd-cat/tinfoil-conformance
+          repository: tinfoilsh/tinfoil-conformance
           ref: main
           path: tinfoil-conformance
           persist-credentials: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,12 @@ dependencies = [
     "urllib3>=2.7.0",
 ]
 
+[project.scripts]
+# Cross-SDK conformance binary (separate from the consumer-facing SDK API).
+# Speaks the JSON-in / JSON-out CLI contract defined in
+# https://github.com/lsd-cat/tinfoil-conformance .
+tinfoil-conformance = "tinfoil.conformance.cli:main"
+
 [dependency-groups]
 dev = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 [project.scripts]
 # Cross-SDK conformance binary (separate from the consumer-facing SDK API).
 # Speaks the JSON-in / JSON-out CLI contract defined in
-# https://github.com/lsd-cat/tinfoil-conformance .
+# https://github.com/tinfoilsh/tinfoil-conformance .
 tinfoil-conformance = "tinfoil.conformance.cli:main"
 
 [dependency-groups]

--- a/src/tinfoil/conformance/__init__.py
+++ b/src/tinfoil/conformance/__init__.py
@@ -1,0 +1,7 @@
+"""tinfoil-conformance binary for tinfoil-python.
+
+Implements the cross-SDK conformance CLI contract defined in
+https://github.com/lsd-cat/tinfoil-conformance. Separate from the
+consumer-facing SDK; this is a thin wrapper that exposes the verifier
+through the JSON-in / JSON-out protocol the harness speaks.
+"""

--- a/src/tinfoil/conformance/__init__.py
+++ b/src/tinfoil/conformance/__init__.py
@@ -1,7 +1,7 @@
 """tinfoil-conformance binary for tinfoil-python.
 
 Implements the cross-SDK conformance CLI contract defined in
-https://github.com/lsd-cat/tinfoil-conformance. Separate from the
+https://github.com/tinfoilsh/tinfoil-conformance. Separate from the
 consumer-facing SDK; this is a thin wrapper that exposes the verifier
 through the JSON-in / JSON-out protocol the harness speaks.
 """

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -143,8 +143,10 @@ def _capabilities() -> dict[str, Any]:
             "legacy_bundle_format_supported": False,
             # sigstore-python hardcodes len(tlog_entries) == 1.
             "accepts_multi_tlog_entries": False,
-            # sigstore-python's policy.OIDCIssuer reads V1 (.1.1) before V2.
-            "oidc_issuer_v2_preferred": False,
+            # tinfoil-python's OIDCIssuerV2Preferred policy reads the canonical
+            # V2 (.1.8) extension first and falls back to the deprecated V1
+            # (.1.1) only when V2 is absent — matching go/rs/js. See SPEC §5.3.
+            "oidc_issuer_v2_preferred": True,
             # sigstore-python collapses missing-SCT and duplicate-SCT into
             # the same "Expected one certificate timestamp" error.
             "scts_count_distinguish_missing_vs_duplicate": False,
@@ -331,9 +333,14 @@ def _classify(message: str) -> Tuple[str, str]:
             return (code, spec_ref)
     low = message.lower()
 
-    # sigstore-python's `policy.OIDCIssuer.verify` raises with a stable
-    # English message form. Catch it before generic patterns.
-    if "oidcissuer does not match" in low or "oidc issuer does not match" in low:
+    # sigstore-python's `OIDCIssuer` (V1) and `OIDCIssuerV2` policies raise
+    # stable English message forms. Catch them before generic patterns. Note
+    # "oidcissuerv2 does not match" contains the "oidcissuer" substring, so the
+    # same check covers both the V1 and V2 phrasings; "does not contain"
+    # handles the missing-extension case (cert carries neither .1.1 nor .1.8).
+    if "oidc issuer does not match" in low or (
+        "oidcissuer" in low and ("does not match" in low or "does not contain" in low)
+    ):
         return ("OIDC_ISSUER_MISMATCH", "5.3")
     if "githubworkflowrepository does not match" in low:
         return ("WORKFLOW_REPOSITORY_MISMATCH", "5.3")

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -22,6 +22,11 @@ import sys
 from typing import Any, Tuple
 
 from ..attestation import verify_tdx_hardware
+from ..attestation.abi_tdx import parse_quote as parse_tdx_quote
+from ..attestation.verify_tdx import (
+    TdxVerificationError,
+    verify_tdx_quote as verify_tdx_quote_crypto,
+)
 from ..attestation.types import (
     FormatMismatchError,
     HardwareMeasurement,
@@ -71,6 +76,7 @@ def _capabilities() -> dict[str, Any]:
             "verify-sigstore",
             "verify-measurement",
             "verify-hardware-measurements",
+            "verify-attestation-tdx",
         ],
         "sigstore": {
             "trust_root_loading": "configurable",
@@ -122,15 +128,18 @@ def _capabilities() -> dict[str, Any]:
             "compare_multiplatform_to_tdx_supported": True,
         },
         "attestation_tdx": {
-            # tinfoil-python has a deep native TDX verifier
-            # (tinfoil.attestation.verify_tdx) but its public API doesn't
-            # currently expose a collateral-injection entry point — it
-            # fetches from Intel PCS. Conformance support lands in Phase 1.5
-            # once we wrap verify_tdx with an injected-collateral path;
-            # declared false here so attestation-tdx fixtures skip cleanly
-            # until then.
-            "supported": False,
-            "injected_collateral_supported": False,
+            # tinfoil-python ships a native TDX verifier with clean
+            # injection-friendly APIs:
+            #   * verify_tdx_quote(quote, raw_quote)  — does Intel §4.1.2
+            #     steps 1-4 (PCK chain, quote sig, QE report sig, AK ↔ QE
+            #     report data binding) with no network calls
+            #   * verify_tcb_info_signature / verify_qe_identity_signature
+            #     accept the raw collateral bytes + issuer chain as args
+            # Phase 1.5 wires the structural verification path
+            # (tcb_evaluation_required=false fixtures). Full TCB evaluation
+            # lands when Phase 3 fixtures need it.
+            "supported": True,
+            "injected_collateral_supported": True,
         },
         "platforms_supported": ["sev-snp", "tdx"],
         "transport_modes_supported": ["tls-pinning"],
@@ -585,6 +594,158 @@ def cmd_verify_hardware_measurements() -> int:
     return EXIT_ACCEPT
 
 
+# -----------------------------------------------------------------------------
+# verify-attestation-tdx (SPEC §4 / Intel TDX DCAP §A.3)
+# -----------------------------------------------------------------------------
+
+TDX_GUEST_V2_URI = "https://tinfoil.sh/predicate/tdx-guest/v2"
+
+
+def _emit_tdx_rejection(code: str, spec_ref: str, message: str) -> int:
+    body = {
+        "stage": "verify-attestation-tdx",
+        "accepted": False,
+        "rejection": {"code": code, "spec_ref": spec_ref, "message": message},
+    }
+    json.dump(body, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return EXIT_REJECT
+
+
+def _classify_tdx_error(err: Exception) -> Tuple[str, str]:
+    msg = str(err).lower()
+    if "signature" in msg:
+        return "QUOTE_SIGNATURE_INVALID", "4.3"
+    if "qe report" in msg or "qe_report" in msg:
+        return "QE_REPORT_SIGNATURE_INVALID", "4.4"
+    if "ak" in msg and ("bind" in msg or "report data" in msg):
+        return "AK_BINDING_INVALID", "4.5"
+    if "pck" in msg and "chain" in msg:
+        return "PCK_CHAIN_INVALID", "4.2"
+    if "expired" in msg:
+        return "PCK_EXPIRED", "4.2"
+    if "root" in msg and ("trust" in msg or "ca" in msg):
+        return "ROOT_CA_UNTRUSTED", "4.2"
+    if "format" in msg or "version" in msg:
+        return "QUOTE_FORMAT_UNSUPPORTED", "A.3"
+    return "QV_RESULT_TERMINAL_UNSPECIFIED", "4.1.2"
+
+
+def _decode_td_attributes(td_attrs: bytes) -> dict[str, bool]:
+    n = int.from_bytes(td_attrs, byteorder="little")
+    return {
+        "tud_debug":                 bool(n & (1 << 0)),
+        "tud_reserved_nonzero":      bool(n & 0xFE),
+        "sec_reserved_lower_nonzero":bool(n & 0x0FFFFF00),
+        "sec_sept_ve_disable":       bool(n & (1 << 28)),
+        "sec_reserved_bit29":        bool(n & (1 << 29)),
+        "sec_pks":                   bool(n & (1 << 30)),
+        "sec_kl":                    bool(n & (1 << 31)),
+        "other_reserved_nonzero":    bool(n & 0x7FFFFFFF00000000),
+        "other_perfmon":             bool(n & (1 << 63)),
+    }
+
+
+def cmd_verify_attestation_tdx() -> int:
+    raw = sys.stdin.read()
+    try:
+        inp = json.loads(raw)
+    except Exception as e:
+        sys.stderr.write(f"input schema violation: {e}\n")
+        return EXIT_BAD_INPUT
+    if inp.get("schema_version") != "1":
+        sys.stderr.write('schema_version must be "1"\n')
+        return EXIT_BAD_INPUT
+
+    try:
+        quote_bytes = base64.b64decode(inp["quote_b64"])
+    except Exception as e:
+        return _emit_tdx_rejection(
+            "QUOTE_FORMAT_UNSUPPORTED", "A.3", f"quote_b64 not valid base64: {e}"
+        )
+
+    try:
+        quote = parse_tdx_quote(quote_bytes)
+    except Exception as e:
+        code, ref = _classify_tdx_error(e)
+        return _emit_tdx_rejection(code, ref, str(e))
+
+    policy = inp.get("policy") or {}
+    # Default true (full §4.7 collateral evaluation). False = structural-only
+    # verification (PCK chain + AK + sig + QE report). Matches the Go binary's
+    # semantics and fixture 300's calibration.
+    tcb_eval_required = policy.get("tcb_evaluation_required", True)
+
+    # Phase 1.5: structural verification only. Phase 3 will add the full
+    # collateral path via verify_tcb_info_signature + verify_qe_identity_
+    # signature + the issuer-chain certs.
+    if tcb_eval_required:
+        return _emit_tdx_rejection(
+            "QV_RESULT_TERMINAL_UNSPECIFIED",
+            "4.7",
+            "tcb_evaluation_required=true not yet wired in tinfoil-python; "
+            "Phase 1.5 only handles the structural path. Use "
+            "tcb_evaluation_required=false for now.",
+        )
+
+    try:
+        verify_tdx_quote_crypto(quote, quote_bytes)
+    except TdxVerificationError as e:
+        code, ref = _classify_tdx_error(e)
+        return _emit_tdx_rejection(code, ref, str(e))
+    except Exception as e:
+        code, ref = _classify_tdx_error(e)
+        return _emit_tdx_rejection(code, ref, f"unexpected: {e}")
+
+    # Build outputs from the parsed body.
+    body = quote.td_quote_body
+    header = quote.header
+    tee_type_str = "TDX" if header.tee_type == 0x81 else f"0x{header.tee_type:08x}"
+
+    out_body = {
+        "stage": "verify-attestation-tdx",
+        "accepted": True,
+        "outputs": {
+            "quote_version": header.version,
+            "tee_type": tee_type_str,
+            "qv_result": "OK",
+            "measurement": {
+                "type": TDX_GUEST_V2_URI,
+                "registers": [
+                    body.mr_td.hex(),
+                    body.rtmrs[0].hex(),
+                    body.rtmrs[1].hex(),
+                    body.rtmrs[2].hex(),
+                    body.rtmrs[3].hex(),
+                ],
+            },
+            "header_fields": {
+                "attestation_key_type": header.attestation_key_type,
+                "qe_vendor_id_hex": header.qe_vendor_id.hex(),
+                "user_data_hex": header.user_data.hex(),
+            },
+            "body_fields": {
+                "tee_tcb_svn_hex": body.tee_tcb_svn.hex(),
+                "mrseam_hex": body.mr_seam.hex(),
+                "mrsignerseam_hex": body.mr_signer_seam.hex(),
+                "seam_attributes_hex": body.seam_attributes.hex(),
+                "td_attributes_hex": body.td_attributes.hex(),
+                "td_attributes_decoded": _decode_td_attributes(body.td_attributes),
+                "xfam_hex": body.xfam.hex(),
+                "mrtd_hex": body.mr_td.hex(),
+                "mrconfigid_hex": body.mr_config_id.hex(),
+                "mrowner_hex": body.mr_owner.hex(),
+                "mrownerconfig_hex": body.mr_owner_config.hex(),
+                "rtmrs_hex": [r.hex() for r in body.rtmrs],
+                "report_data_hex": body.report_data.hex(),
+            },
+        },
+    }
+    json.dump(out_body, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return EXIT_ACCEPT
+
+
 def main(argv: list[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
@@ -599,6 +760,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_verify_measurement()
     if sub == "verify-hardware-measurements":
         return cmd_verify_hardware_measurements()
+    if sub == "verify-attestation-tdx":
+        return cmd_verify_attestation_tdx()
     if sub in ("", "help", "-h", "--help"):
         _print_help()
         return EXIT_ACCEPT

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -1879,7 +1879,16 @@ def _cmd_verify_attestation_sev_public(data: dict[str, Any]) -> int:
             code, ref = "REPORT_SIGNATURE_INVALID", "3.6"
         return _emit_sev_rejection(code, ref, str(err) or diag)
 
-    # Verifier accepted. Emit the same body_fields output shape as the adapter.
+    # The lib's verifier ran the §3.4 VCEK cross-checks and crypto. Apply the
+    # fixture's §3.7 policy pins (measurement, host_data, report_data, key
+    # digests, TCB minimums) — caller policy the public verifier doesn't know
+    # about — mirroring the Go public handler and the adapter path. Without
+    # this, policy-mismatch fixtures would wrongly accept in full flow.
+    pol_viol = _enforce_sev_policy(report_bytes, data.get("policy"))
+    if pol_viol:
+        code, ref, msg = pol_viol
+        return _emit_sev_rejection(code, ref, msg)
+
     body_fields = _decode_sev_body_fields(report_bytes)
     out_body = {
         "stage": "verify-attestation-sev",

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -67,6 +67,8 @@ from ..attestation.types import (
     MULTIPLATFORM_REGISTER_COUNT,
     SEV_REGISTER_COUNT,
     TDX_REGISTER_COUNT,
+    TLS_KEY_FP_SIZE,
+    HPKE_KEY_SIZE,
 )
 from .sigstore import (
     SigstorePolicy,
@@ -108,6 +110,7 @@ def _capabilities() -> dict[str, Any]:
             "verify-attestation-tdx",
             "verify-attestation-sev",
             "verify-full",
+            "verify-ehbp-key-binding",
         ],
         "sigstore": {
             "trust_root_loading": "configurable",
@@ -238,6 +241,10 @@ def _capabilities() -> dict[str, Any]:
         # bundle.py, client.verify_from_bundle).
         "transport_modes_supported": ["tls-pinning", "ehbp"],
         "flow_modes_supported": ["standard", "bundle", "pinned"],
+        # SPEC §14.2 EHBP key binding: the transport HPKE key must equal the
+        # attested key from report_data[32:64]. The SDK binds by construction
+        # (_build_ehbp_sync_transport seals only to the attested key).
+        "ehbp": {"key_binding_supported": True},
         "known_quirks": {
             "sigstore.workflow_ref_check_via_startswith":
                 "We replaced sigstore.verify.policy's regex-based GitHubWorkflowRefPattern with a strict-prefix startswith() check (SPEC §5.3 reads as prefix, not regex).",
@@ -2003,6 +2010,88 @@ def cmd_verify_full() -> int:
     )
 
 
+# -----------------------------------------------------------------------------
+# verify-ehbp-key-binding (SPEC §14.2)
+# -----------------------------------------------------------------------------
+
+
+def cmd_verify_ehbp_key_binding() -> int:
+    """Tinfoil SPEC §14.2: the EHBP transport HPKE key MUST equal the attested
+    key from report_data[32:64]; a server-offered key that differs is rejected.
+    Hermetic — no network. Uses the SDK's real report_data layout constants and
+    the real ehbp ServerIdentity key parser the transport relies on."""
+    try:
+        raw = sys.stdin.read()
+    except Exception as e:  # pragma: no cover
+        sys.stderr.write(f"error reading stdin: {e}\n")
+        return EXIT_INTERNAL
+
+    try:
+        inp = json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"input is not valid JSON: {e}\n")
+        return EXIT_BAD_INPUT
+    if inp.get("schema_version") != "1":
+        sys.stderr.write('input.schema_version != "1"\n')
+        return EXIT_BAD_INPUT
+
+    try:
+        report_data = bytes.fromhex(inp.get("report_data_hex", ""))
+    except ValueError as e:
+        sys.stderr.write(f"report_data_hex not valid hex: {e}\n")
+        return EXIT_BAD_INPUT
+
+    # SPEC §14.2 layout: [0:32] = TLS SPKI fingerprint, [32:64] = HPKE key.
+    # Uses the SDK's own size constants (the same slice verify_sev/tdx applies).
+    if len(report_data) != TLS_KEY_FP_SIZE + HPKE_KEY_SIZE:
+        sys.stderr.write(
+            f"report_data must be {TLS_KEY_FP_SIZE + HPKE_KEY_SIZE} bytes, "
+            f"got {len(report_data)}\n"
+        )
+        return EXIT_BAD_INPUT
+    tls_fingerprint = report_data[:TLS_KEY_FP_SIZE].hex()
+    attested = report_data[TLS_KEY_FP_SIZE:TLS_KEY_FP_SIZE + HPKE_KEY_SIZE].hex()
+
+    # Validate the offered key through the same EHBP key parser the transport
+    # uses (_build_ehbp_sync_transport -> EHBPTransport.from_public_key_hex ->
+    # ehbp.ServerIdentity.from_public_key_hex).
+    from ehbp import ServerIdentity
+
+    try:
+        offered = ServerIdentity.from_public_key_hex(
+            inp.get("offered_hpke_public_key_hex", "")
+        ).public_key_hex()
+    except Exception as e:
+        sys.stderr.write(f"offered hpke key not a valid X25519 public key: {e}\n")
+        return EXIT_BAD_INPUT
+
+    if offered.lower() != attested.lower():
+        body = {
+            "stage": "verify-ehbp-key-binding",
+            "accepted": False,
+            "rejection": {
+                "code": "EHBP_KEY_BINDING_MISMATCH",
+                "spec_ref": "14.2",
+                "message": "offered HPKE key does not match the attested key in report_data[32:64]",
+            },
+        }
+        json.dump(body, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return EXIT_REJECT
+
+    body = {
+        "stage": "verify-ehbp-key-binding",
+        "accepted": True,
+        "outputs": {
+            "attested_hpke_public_key_hex": attested,
+            "tls_fingerprint_hex": tls_fingerprint,
+        },
+    }
+    json.dump(body, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return EXIT_ACCEPT
+
+
 def main(argv: list[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
@@ -2023,6 +2112,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_verify_attestation_sev()
     if sub == "verify-full":
         return cmd_verify_full()
+    if sub == "verify-ehbp-key-binding":
+        return cmd_verify_ehbp_key_binding()
     if sub in ("", "help", "-h", "--help"):
         _print_help()
         return EXIT_ACCEPT

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -217,6 +217,11 @@ def _capabilities() -> dict[str, Any]:
             # (bypassing CertificateChain.from_report's KDS fetch).
             "supported": True,
             "injected_collateral_supported": True,
+            # execution_mode=public_api drives the SDK's real public verifier
+            # (attestation.verify_sev_attestation_v2) with only the VCEK
+            # injected (embedded ARK/ASK, no network) — see
+            # _cmd_verify_attestation_sev_public.
+            "public_api_hooks_supported": True,
             # _enforce_sev_policy applies SPEC §3.7/§3.8/§8.2-3 pins from
             # policy.expected_*_hex and enforce_spec_defaults checks.
             "extended_checks_supported": True,
@@ -1811,6 +1816,87 @@ def _run_verify_attestation_sev_inner(
     return (measurement, report_bytes, body_fields)
 
 
+def _cmd_verify_attestation_sev_public(data: dict[str, Any]) -> int:
+    """execution_mode=public_api: drive the SDK's real public SEV verifier
+    (attestation.verify_sev_attestation_v2) with only the VCEK injected — the
+    SDK uses its embedded Genoa ARK/ASK, so no AMD KDS network call. Confirms
+    the report-parse / signature / VCEK-chain checks are reachable from the
+    SDK's public surface, unlike the adapter path which assembles the chain and
+    runs verify_attestation directly.
+
+    Fixtures needing an injected ARK/ASK, a verification-time override, or §3.7
+    policy pins enforced by the verifier stay adapter-only.
+    """
+    import gzip as _gzip
+    import io as _io
+
+    from ..attestation import verify_sev_attestation_v2
+
+    doc_b64 = data.get("attestation_doc_b64", "")
+    # Length pre-check keeps REPORT_TRUNCATED distinct from the parser's generic
+    # REPORT_FORMAT_UNSUPPORTED, matching the adapter and the Go binary.
+    try:
+        report_bytes = _gzip.decompress(base64.standard_b64decode(doc_b64))
+    except Exception as e:
+        return _emit_sev_rejection(
+            "REPORT_FORMAT_UNSUPPORTED", "3.1",
+            f"attestation_doc_b64 decode/decompress failed: {e}")
+    if len(report_bytes) < _SEV_REPORT_LEN:
+        return _emit_sev_rejection(
+            "REPORT_TRUNCATED", "3.1",
+            f"SEV report is {len(report_bytes)} bytes, expected ≥{_SEV_REPORT_LEN}")
+
+    try:
+        vcek_der = base64.standard_b64decode(data.get("vcek_der_b64", ""))
+    except Exception as e:
+        return _emit_sev_rejection(
+            "VCEK_CHAIN_INVALID", "3.3", f"vcek_der_b64 not valid base64: {e}")
+
+    # verify_sev_attestation_v2 / verify_chain print failure diagnostics via
+    # print() to stdout; the conformance contract is JSON-only on stdout, so
+    # capture stdout, route it to stderr, and classify on the captured text +
+    # the raised exception (the lib often raises a generic message while the
+    # specific reason is printed).
+    captured = _io.StringIO()
+    orig_stdout = sys.stdout
+    sys.stdout = captured
+    err: Exception | None = None
+    try:
+        verify_sev_attestation_v2(doc_b64, vcek_der=vcek_der)
+    except Exception as e:  # noqa: BLE001 — lib raises ValueError/SevAttestationError
+        err = e
+    finally:
+        sys.stdout = orig_stdout
+    lib_diag = captured.getvalue()
+    if lib_diag:
+        sys.stderr.write(lib_diag)
+    if err is not None:
+        diag = f"{lib_diag} {err}".strip()
+        code, ref = _classify_sev_error(diag)
+        if code == "QV_RESULT_TERMINAL_UNSPECIFIED":
+            # A verify-stage failure the classifier couldn't pin: it is a
+            # report/VCEK signature problem (§3.6).
+            code, ref = "REPORT_SIGNATURE_INVALID", "3.6"
+        return _emit_sev_rejection(code, ref, str(err) or diag)
+
+    # Verifier accepted. Emit the same body_fields output shape as the adapter.
+    body_fields = _decode_sev_body_fields(report_bytes)
+    out_body = {
+        "stage": "verify-attestation-sev",
+        "accepted": True,
+        "outputs": {
+            "measurement": {
+                "type": SEV_GUEST_V2_URI,
+                "registers": [body_fields["measurement_hex"]],
+            },
+            "body_fields": body_fields,
+        },
+    }
+    json.dump(out_body, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return EXIT_ACCEPT
+
+
 def cmd_verify_attestation_sev() -> int:
     try:
         raw = sys.stdin.read()
@@ -1825,6 +1911,9 @@ def cmd_verify_attestation_sev() -> int:
     if data.get("schema_version") != "1":
         sys.stderr.write('schema_version must be "1"\n')
         return EXIT_BAD_INPUT
+
+    if data.get("execution_mode") == "public_api":
+        return _cmd_verify_attestation_sev_public(data)
 
     result = _run_verify_attestation_sev_inner(data)
     # Disambiguate success (Measurement, bytes, dict) vs rejection (str, str, str).

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -68,7 +68,7 @@ from ..attestation.types import (
     SEV_REGISTER_COUNT,
     TDX_REGISTER_COUNT,
 )
-from ..sigstore import (
+from .sigstore import (
     SigstorePolicy,
     SigstoreVerification,
     default_sigstore_policy,

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -23,6 +23,11 @@ from typing import Any, Tuple
 
 from ..attestation import verify_tdx_hardware
 from ..attestation.abi_tdx import parse_quote as parse_tdx_quote
+from ..attestation.attestation_tdx import (
+    TdxAttestationError,
+    TdxVerificationConfig,
+    verify_tdx_attestation,
+)
 from ..attestation.verify_tdx import (
     TdxVerificationError,
     extract_pck_cert_chain,
@@ -180,6 +185,11 @@ def _capabilities() -> dict[str, Any]:
             # validate_tdx_module_identity + validate_qe_identity) using
             # the fixture-injected collateral bytes — no Intel PCS fetch.
             "tcb_evaluation_supported": True,
+            # execution_mode=public_api calls the public verify_tdx_attestation
+            # path and monkey-patches only the collateral fetch boundary inside
+            # this conformance process, so production attestation modules do
+            # not need test-only hook parameters.
+            "public_api_hooks_supported": True,
             # Phase 4: cmd_verify_attestation_tdx applies SPEC §4.8 /
             # Intel §2.3.2 checks against every policy.expected_*_hex pin
             # the fixture sets — the unmutated quote's body fields are
@@ -694,6 +704,40 @@ def _classify_tdx_error(err: Exception) -> Tuple[str, str]:
     # Order matters: chain errors mention "signature" but should map to
     # PCK_CHAIN_INVALID, not QUOTE_SIGNATURE_INVALID.
 
+    # Collateral-layer failures as surfaced by the public verifier.
+    if "pck crl" in msg and "expired" in msg:
+        return "PCK_CRL_EXPIRED", "4.7.4"
+    if ("root ca crl" in msg or "root crl" in msg) and "expired" in msg:
+        return "ROOT_CRL_EXPIRED", "4.7.4"
+    if "tcb info" in msg and "expired" in msg:
+        return "TCB_INFO_EXPIRED", "4.7"
+    if ("qe identity" in msg or "enclave identity" in msg) and "expired" in msg:
+        return "QE_IDENTITY_EXPIRED", "4.7"
+    if "tcbevaluationdatanumber" in msg or "tcb evaluation data number" in msg:
+        return "TCB_EVAL_DATA_NUMBER_TOO_LOW", "4.7.11"
+    if "intermediate ca" in msg and "revoked" in msg:
+        return "INTERMEDIATE_REVOKED", "4.7.4"
+    if "pck certificate" in msg and "revoked" in msg:
+        return "PCK_REVOKED", "4.7.4"
+    if "tcb info issuer chain" in msg and (
+        "chain" in msg or "certificate" in msg or "root" in msg
+    ):
+        return "TCB_INFO_CHAIN_INVALID", "4.7.3"
+    if "qe identity id" in msg and ("td_qe" in msg or "must" in msg):
+        return "QE_IDENTITY_ID_INVALID", "4.7.9"
+    if "qe identity version" in msg and "must" in msg:
+        return "QE_IDENTITY_VERSION_INVALID", "4.7.9"
+    if ("qe identity" in msg or "enclave identity" in msg) and (
+        "mrsigner" in msg or "mr_signer" in msg
+    ):
+        return "QE_IDENTITY_MRSIGNER_MISMATCH", "4.7.9"
+    if ("qe identity" in msg or "enclave identity" in msg) and (
+        "miscselect" in msg or "attributes" in msg or "isv prodid" in msg
+    ):
+        return "QE_IDENTITY_FIELD_MISMATCH", "4.7.9"
+    if "tcb status" in msg or "no matching tcb" in msg or "tcb is revoked" in msg:
+        return "TCB_REVOKED", "4.7.7"
+
     # Quote header / structural parse failures
     if "invalid tee type" in msg or "tee type" in msg:
         return "WRONG_TEE_TYPE", "A.3.1"
@@ -753,6 +797,125 @@ def _decode_td_attributes(td_attrs: bytes) -> dict[str, bool]:
         "other_reserved_nonzero":    bool(n & 0x7FFFFFFF00000000),
         "other_perfmon":             bool(n & (1 << 63)),
     }
+
+
+def _tdx_acceptance_output(quote) -> dict[str, Any]:
+    body = quote.td_quote_body
+    header = quote.header
+    tee_type_str = "TDX" if header.tee_type == 0x81 else f"0x{header.tee_type:08x}"
+
+    return {
+        "stage": "verify-attestation-tdx",
+        "accepted": True,
+        "outputs": {
+            "quote_version": header.version,
+            "tee_type": tee_type_str,
+            "qv_result": "OK",
+            "measurement": {
+                "type": TDX_GUEST_V2_URI,
+                "registers": [
+                    body.mr_td.hex(),
+                    body.rtmrs[0].hex(),
+                    body.rtmrs[1].hex(),
+                    body.rtmrs[2].hex(),
+                    body.rtmrs[3].hex(),
+                ],
+            },
+            "header_fields": {
+                "attestation_key_type": header.attestation_key_type,
+                "qe_vendor_id_hex": header.qe_vendor_id.hex(),
+                "user_data_hex": header.user_data.hex(),
+            },
+            "body_fields": {
+                "tee_tcb_svn_hex": body.tee_tcb_svn.hex(),
+                "mrseam_hex": body.mr_seam.hex(),
+                "mrsignerseam_hex": body.mr_signer_seam.hex(),
+                "seam_attributes_hex": body.seam_attributes.hex(),
+                "td_attributes_hex": body.td_attributes.hex(),
+                "td_attributes_decoded": _decode_td_attributes(body.td_attributes),
+                "xfam_hex": body.xfam.hex(),
+                "mrtd_hex": body.mr_td.hex(),
+                "mrconfigid_hex": body.mr_config_id.hex(),
+                "mrowner_hex": body.mr_owner.hex(),
+                "mrownerconfig_hex": body.mr_owner_config.hex(),
+                "rtmrs_hex": [r.hex() for r in body.rtmrs],
+                "report_data_hex": body.report_data.hex(),
+            },
+        },
+    }
+
+
+def _tdx_fixture_collateral(
+    collateral_in: dict[str, Any],
+    pck_cert,
+) -> TdxCollateral:
+    tcb_info_raw = (collateral_in.get("tcb_info_json") or "").encode()
+    qe_identity_raw = (collateral_in.get("qe_identity_json") or "").encode()
+    tcb_info = parse_tcb_info_response(tcb_info_raw)
+    qe_identity = parse_qe_identity_response(qe_identity_raw)
+
+    tcb_issuer_chain_pem = (collateral_in.get("tcb_info_issuer_chain_pem") or "").encode()
+    qe_issuer_chain_pem = (collateral_in.get("qe_identity_issuer_chain_pem") or "").encode()
+    pck_crl_issuer_chain_pem = (collateral_in.get("pck_crl_issuer_chain_pem") or "").encode()
+
+    tcb_issuer_chain = parse_pem_chain(tcb_issuer_chain_pem) if tcb_issuer_chain_pem else []
+    qe_issuer_chain = parse_pem_chain(qe_issuer_chain_pem) if qe_issuer_chain_pem else []
+    pck_crl_issuer_chain = (
+        parse_pem_chain(pck_crl_issuer_chain_pem) if pck_crl_issuer_chain_pem else []
+    )
+
+    if tcb_issuer_chain:
+        verify_tcb_info_signature(tcb_info_raw, tcb_info, tcb_issuer_chain)
+    if qe_issuer_chain:
+        verify_qe_identity_signature(qe_identity_raw, qe_identity, qe_issuer_chain)
+
+    pck_crl_obj = None
+    pck_crl_der = base64.b64decode(collateral_in.get("pck_crl_der_b64") or "")
+    if pck_crl_der:
+        pck_crl = x509.load_der_x509_crl(pck_crl_der)
+        ca_type = _coll._determine_pck_ca_type(pck_cert)
+        if pck_crl_issuer_chain:
+            _coll._verify_crl_signature(pck_crl, pck_crl_issuer_chain, ca_type)
+        pck_crl_obj = PckCrl(
+            crl=pck_crl,
+            ca_type=ca_type,
+            next_update=pck_crl.next_update_utc or datetime.now(timezone.utc),
+        )
+
+    root_crl_obj = None
+    root_crl_der = base64.b64decode(collateral_in.get("root_crl_der_b64") or "")
+    if root_crl_der:
+        root_crl = x509.load_der_x509_crl(root_crl_der)
+        _coll._verify_root_crl_signature(root_crl)
+        root_crl_obj = RootCrl(
+            crl=root_crl,
+            next_update=root_crl.next_update_utc or datetime.now(timezone.utc),
+        )
+
+    return TdxCollateral(
+        tcb_info=tcb_info,
+        qe_identity=qe_identity,
+        tcb_info_raw=tcb_info_raw,
+        qe_identity_raw=qe_identity_raw,
+        pck_crl=pck_crl_obj,
+        root_crl=root_crl_obj,
+        tcb_info_issuer_chain=tcb_issuer_chain or None,
+        qe_identity_issuer_chain=qe_issuer_chain or None,
+    )
+
+
+@contextlib.contextmanager
+def _maybe_override_tdx_fetch_collateral(collateral_in: dict[str, Any]):
+    orig_fetch_collateral = _coll.fetch_collateral
+
+    def _fixture_fetch_collateral(pck_extensions, pck_cert, *args, **kwargs):
+        return _tdx_fixture_collateral(collateral_in, pck_cert)
+
+    _coll.fetch_collateral = _fixture_fetch_collateral
+    try:
+        yield
+    finally:
+        _coll.fetch_collateral = orig_fetch_collateral
 
 
 @contextlib.contextmanager
@@ -1100,6 +1263,45 @@ def _enforce_extended_policy(
     return "", ""
 
 
+def _cmd_verify_attestation_tdx_public(inp: dict[str, Any], policy: dict[str, Any]) -> int:
+    collateral_in = inp.get("collateral") or {}
+    custom_root_pem = collateral_in.get("intel_root_ca_pem")
+    fixture_date = inp.get("expiration_check_date_unix")
+
+    config_kwargs: dict[str, Any] = {}
+    if policy.get("min_tcb_evaluation_data_number") is not None:
+        config_kwargs["min_tcb_evaluation_data_number"] = int(
+            policy["min_tcb_evaluation_data_number"]
+        )
+
+    with (
+        _maybe_override_intel_root(custom_root_pem),
+        _maybe_override_time(fixture_date),
+        _maybe_override_tdx_fetch_collateral(collateral_in),
+    ):
+        try:
+            result = verify_tdx_attestation(
+                inp["quote_b64"],
+                is_compressed=False,
+                config=TdxVerificationConfig(**config_kwargs),
+            )
+        except (TdxAttestationError, TdxVerificationError, CollateralError) as e:
+            code, ref = _classify_tdx_error(e)
+            return _emit_tdx_rejection(code, ref, str(e))
+        except Exception as e:
+            code, ref = _classify_tdx_error(e)
+            return _emit_tdx_rejection(code, ref, f"unexpected: {e}")
+
+    quote_bytes = base64.b64decode(inp["quote_b64"])
+    code, msg = _enforce_extended_policy(quote_bytes, policy)
+    if code:
+        return _emit_tdx_rejection(code, "4.8", msg)
+
+    json.dump(_tdx_acceptance_output(result.quote), sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return EXIT_ACCEPT
+
+
 def cmd_verify_attestation_tdx() -> int:
     raw = sys.stdin.read()
     try:
@@ -1129,6 +1331,8 @@ def cmd_verify_attestation_tdx() -> int:
     # verification (PCK chain + AK + sig + QE report). Matches the Go binary's
     # semantics and fixture 300's calibration.
     tcb_eval_required = policy.get("tcb_evaluation_required", True)
+    if inp.get("execution_mode") == "public_api":
+        return _cmd_verify_attestation_tdx_public(inp, policy)
 
     # Structural verification (Intel §4.1.2 steps 1-4) always runs.
     # When collateral.intel_root_ca_pem is set (Phase 3 synthetic chain
@@ -1165,51 +1369,7 @@ def cmd_verify_attestation_tdx() -> int:
     if code:
         return _emit_tdx_rejection(code, "4.8", msg)
 
-    # Build outputs from the parsed body.
-    body = quote.td_quote_body
-    header = quote.header
-    tee_type_str = "TDX" if header.tee_type == 0x81 else f"0x{header.tee_type:08x}"
-
-    out_body = {
-        "stage": "verify-attestation-tdx",
-        "accepted": True,
-        "outputs": {
-            "quote_version": header.version,
-            "tee_type": tee_type_str,
-            "qv_result": "OK",
-            "measurement": {
-                "type": TDX_GUEST_V2_URI,
-                "registers": [
-                    body.mr_td.hex(),
-                    body.rtmrs[0].hex(),
-                    body.rtmrs[1].hex(),
-                    body.rtmrs[2].hex(),
-                    body.rtmrs[3].hex(),
-                ],
-            },
-            "header_fields": {
-                "attestation_key_type": header.attestation_key_type,
-                "qe_vendor_id_hex": header.qe_vendor_id.hex(),
-                "user_data_hex": header.user_data.hex(),
-            },
-            "body_fields": {
-                "tee_tcb_svn_hex": body.tee_tcb_svn.hex(),
-                "mrseam_hex": body.mr_seam.hex(),
-                "mrsignerseam_hex": body.mr_signer_seam.hex(),
-                "seam_attributes_hex": body.seam_attributes.hex(),
-                "td_attributes_hex": body.td_attributes.hex(),
-                "td_attributes_decoded": _decode_td_attributes(body.td_attributes),
-                "xfam_hex": body.xfam.hex(),
-                "mrtd_hex": body.mr_td.hex(),
-                "mrconfigid_hex": body.mr_config_id.hex(),
-                "mrowner_hex": body.mr_owner.hex(),
-                "mrownerconfig_hex": body.mr_owner_config.hex(),
-                "rtmrs_hex": [r.hex() for r in body.rtmrs],
-                "report_data_hex": body.report_data.hex(),
-            },
-        },
-    }
-    json.dump(out_body, sys.stdout, indent=2, sort_keys=True)
+    json.dump(_tdx_acceptance_output(quote), sys.stdout, indent=2, sort_keys=True)
     sys.stdout.write("\n")
     return EXIT_ACCEPT
 

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -137,9 +137,9 @@ def _capabilities() -> dict[str, Any]:
             "predicate_types_understood": [
                 "https://tinfoil.sh/predicate/snp-tdx-multiplatform/v1",
             ],
-            # sigstore-python 4.x normalizes bundles via Bundle.from_json
-            # which only accepts the v0.3 mediaType; the older
-            # x509CertificateChain layout would need conversion before load.
+            # reject_legacy_bundle_format rejects the v0.1/v0.2
+            # x509CertificateChain layout; only the v0.3 single-certificate
+            # form is accepted. SPEC §5.2.
             "legacy_bundle_format_supported": False,
             # sigstore-python hardcodes len(tlog_entries) == 1.
             "accepts_multi_tlog_entries": False,
@@ -333,6 +333,11 @@ def _classify(message: str) -> Tuple[str, str]:
         if message.startswith(prefix) or prefix in message:
             return (code, spec_ref)
     low = message.lower()
+
+    # Legacy (v0.1/v0.2 x509CertificateChain) bundle layout, rejected by
+    # reject_legacy_bundle_format.
+    if "legacy bundle format" in low:
+        return ("BUNDLE_MALFORMED", "5.2")
 
     # sigstore-python's `OIDCIssuer` (V1) and `OIDCIssuerV2` policies raise
     # stable English message forms. Catch them before generic patterns. Note

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -101,6 +101,7 @@ def _capabilities() -> dict[str, Any]:
             "verify-measurement",
             "verify-hardware-measurements",
             "verify-attestation-tdx",
+            "verify-attestation-sev",
         ],
         "sigstore": {
             "trust_root_loading": "configurable",
@@ -190,6 +191,27 @@ def _capabilities() -> dict[str, Any]:
             # urationNeeded, ConfigurationAndSWHardeningNeeded) pass
             # through per SPEC §4.7.7 default.
             "accepts_non_terminal_tcb_statuses": True,
+        },
+        "attestation_sev": {
+            # cmd_verify_attestation_sev builds CertificateChain directly
+            # with the fixture-supplied VCEK + lib's embedded ARK/ASK
+            # (bypassing CertificateChain.from_report's KDS fetch).
+            "supported": True,
+            "injected_collateral_supported": True,
+            # _enforce_sev_policy applies SPEC §3.7/§3.8/§8.2-3 pins from
+            # policy.expected_*_hex and enforce_spec_defaults checks.
+            "extended_checks_supported": True,
+            # Python's verify_chain uses pyOpenSSL X509Store.verify_certificate
+            # which delegates cert validity to OpenSSL's internal system-clock
+            # check. No Python-level monkey-patch can override it; fixture
+            # 240-vcek-expired skips on tinfoil-python.
+            "verification_time_override": "system-clock-only",
+            # cmd_verify_attestation_sev parses input.amd_root_ca_pem /
+            # input.ask_pem when set and passes them into CertificateChain
+            # instead of the lib's embedded ARK_CERT/ASK_CERT constants.
+            # No lib changes required — the conformance binary owns the
+            # construction of CertificateChain.
+            "amd_root_ca_injection_supported": True,
         },
         "platforms_supported": ["sev-snp", "tdx"],
         "transport_modes_supported": ["tls-pinning"],
@@ -1114,6 +1136,452 @@ def cmd_verify_attestation_tdx() -> int:
     return EXIT_ACCEPT
 
 
+# =============================================================================
+# verify-attestation-sev (SPEC §3 / AMD SEV-SNP)
+# =============================================================================
+
+SEV_GUEST_V2_URI = "https://tinfoil.sh/predicate/sev-snp-guest/v2"
+
+
+def _emit_sev_rejection(code: str, spec_ref: str, message: str) -> int:
+    body = {
+        "stage": "verify-attestation-sev",
+        "accepted": False,
+        "rejection": {"code": code, "spec_ref": spec_ref, "message": message},
+    }
+    json.dump(body, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return EXIT_REJECT
+
+
+_SEV_REPORT_LEN = 1184
+
+
+def _decode_sev_body_fields(report: bytes) -> dict[str, Any]:
+    """Decode the 1184-byte SEV-SNP v3 report into the same shape as the
+    Go conformance binary's buildSevOutputs, so expected.json pinned
+    outputs are cross-SDK comparable byte-for-byte."""
+    def u32(off: int) -> int:
+        return int.from_bytes(report[off:off + 4], "little")
+
+    def u64(off: int) -> int:
+        return int.from_bytes(report[off:off + 8], "little")
+
+    policy = u64(0x08)
+    current_tcb = u64(0x38)
+    platform_info = u64(0x40)
+
+    def b(n: int, i: int) -> bool:
+        return bool((n >> i) & 1)
+
+    return {
+        "version": u32(0x00),
+        "guest_svn": u32(0x04),
+        "policy_hex": f"{policy:016x}",
+        "policy_decoded": {
+            "abi_minor": policy & 0xff,
+            "abi_major": (policy >> 8) & 0xff,
+            "smt": b(policy, 16),
+            "reserved_mbo": b(policy, 17),
+            "migrate_ma": b(policy, 18),
+            "debug": b(policy, 19),
+            "single_socket": b(policy, 20),
+            "cxl_allow": b(policy, 21),
+            "mem_aes_256_xts": b(policy, 22),
+            "raplmsr_dis": b(policy, 23),
+            "ciphertext_hiding_dram": b(policy, 24),
+        },
+        "family_id_hex": report[0x10:0x20].hex(),
+        "image_id_hex": report[0x20:0x30].hex(),
+        "vmpl": u32(0x30),
+        "signature_algo": u32(0x34),
+        "current_tcb_hex": f"{current_tcb:016x}",
+        "current_tcb_decoded": {
+            "bl_spl": current_tcb & 0xff,
+            "tee_spl": (current_tcb >> 8) & 0xff,
+            "snp_spl": (current_tcb >> 48) & 0xff,
+            "ucode_spl": (current_tcb >> 56) & 0xff,
+        },
+        "platform_info_hex": f"{platform_info:016x}",
+        "platform_info_decoded": {
+            "smt_en": b(platform_info, 0),
+            "tsme_en": b(platform_info, 1),
+            "ecc_en": b(platform_info, 2),
+            "rapl_dis": b(platform_info, 3),
+            "ciphertext_hiding": b(platform_info, 4),
+        },
+        "signer_info_hex": f"{u32(0x48):08x}",
+        "report_data_hex": report[0x50:0x90].hex(),
+        "measurement_hex": report[0x90:0x90 + 48].hex(),
+        "host_data_hex": report[0xC0:0xC0 + 32].hex(),
+        "id_key_digest_hex": report[0xE0:0xE0 + 48].hex(),
+        "author_key_digest_hex": report[0x110:0x110 + 48].hex(),
+        "report_id_hex": report[0x140:0x140 + 32].hex(),
+        "report_id_ma_hex": report[0x160:0x160 + 32].hex(),
+        "reported_tcb_hex": report[0x180:0x180 + 8].hex(),
+        "chip_id_hex": report[0x1A0:0x1A0 + 64].hex(),
+        "committed_tcb_hex": report[0x1E8:0x1E8 + 8].hex(),
+        "current_build": report[0x1F0],
+        "current_minor": report[0x1F1],
+        "current_major": report[0x1F2],
+        "committed_build": report[0x1F4],
+        "committed_minor": report[0x1F5],
+        "committed_major": report[0x1F6],
+        "launch_tcb_hex": report[0x1F8:0x1F8 + 8].hex(),
+    }
+
+
+def _classify_sev_error(msg: str) -> tuple[str, str]:
+    low = msg.lower()
+    # Order matters — specific before generic.
+    # SPEC §3.2.2: tinfoil-python's Report parser raises various phrasings
+    # for guest_policy bit violations:
+    #   "policy[17] is reserved, must be 1, got 0"   (reserved-MBO at bit 17)
+    #   "policy bits 63-26 must be zero"             (reserved-MBZ at bits 25+)
+    if ("policy[" in low or "guest policy" in low or "policy bit" in low) and (
+        "reserved" in low or "mbz" in low or "must be" in low
+    ):
+        return "GUEST_POLICY_RESERVED_BIT_SET", "3.2.2"
+    if "expired" in low or "not yet valid" in low:
+        return "VCEK_EXPIRED", "3.3.3"
+    if "hwid" in low:
+        return "VCEK_HWID_MISMATCH", "3.4.4"
+    if "vcek" in low and "tcb" in low:
+        return "VCEK_TCB_MISMATCH", "3.4.3"
+    if "report signature" in low or "signature verification failed" in low \
+            or "signature is invalid" in low or "report was not signed" in low:
+        return "REPORT_SIGNATURE_INVALID", "3.6"
+    if "ark" in low and "self-sign" in low:
+        return "ARK_UNTRUSTED", "3.3.1"
+    if ("ask" in low and "not signed" in low) or "ask invalid" in low:
+        return "ASK_INVALID", "3.3.2"
+    if ("vcek" in low and ("chain" in low or "verify" in low or "signed" in low)) \
+            or "amd certificate chain" in low or "certificate chain verification" in low \
+            or "certificate signature failure" in low \
+            or "malformed certificate" in low \
+            or "could not interpret vcek" in low or "failed to build certificate chain" in low \
+            or "invalid vcek" in low or "x509" in low:
+        return "VCEK_CHAIN_INVALID", "3.3.5"
+    if "report length" in low or "less than" in low and "byte" in low:
+        return "REPORT_TRUNCATED", "3.1"
+    if "failed to decompress" in low or "failed to decode base64" in low \
+            or "failed to parse report" in low or "format" in low:
+        return "REPORT_FORMAT_UNSUPPORTED", "3.1"
+    return "QV_RESULT_TERMINAL_UNSPECIFIED", "3"
+
+
+_AMD_OID_BL_SPL = "1.3.6.1.4.1.3704.1.3.1"
+_AMD_OID_TEE_SPL = "1.3.6.1.4.1.3704.1.3.2"
+_AMD_OID_SNP_SPL = "1.3.6.1.4.1.3704.1.3.3"
+_AMD_OID_UCODE_SPL = "1.3.6.1.4.1.3704.1.3.8"
+_AMD_OID_HWID = "1.3.6.1.4.1.3704.1.4"
+
+
+def _decode_int_ext_value(raw: bytes) -> int | None:
+    """Decode an AMD KDS SPL extension value (DER INTEGER) to a Python int."""
+    # raw is the extension OCTET STRING contents — an INTEGER TLV: 02 LL VV...
+    if len(raw) < 3 or raw[0] != 0x02:
+        return None
+    length = raw[1]
+    if len(raw) < 2 + length:
+        return None
+    return int.from_bytes(raw[2:2 + length], "big", signed=False)
+
+
+def _enforce_sev_vcek_cross_checks(
+    report: bytes,
+    vcek_cert,
+) -> tuple[str, str, str] | None:
+    """SPEC §3.4 mandatory cross-checks: VCEK extensions ↔ report fields.
+    The lib's validate_report has these, but we bypass that call so we
+    can run fixture-specific policy enforcement separately. Replicate
+    the mandatory checks here so synth-chain mismatches don't slip
+    through as ACCEPTED."""
+    from cryptography.x509 import ObjectIdentifier as _OID
+    try:
+        ext_map: dict[str, bytes] = {}
+        for ext in vcek_cert.extensions:
+            try:
+                ext_map[ext.oid.dotted_string] = bytes(ext.value.value)
+            except Exception:
+                pass
+    except Exception:
+        return None
+
+    # HWID cross-check
+    hwid_raw = ext_map.get(_AMD_OID_HWID)
+    if hwid_raw is None:
+        return "VCEK_HWID_MISMATCH", "3.4.4", "VCEK certificate missing HWID extension"
+    if hwid_raw != report[0x1A0:0x1A0 + 64]:
+        return ("VCEK_HWID_MISMATCH", "3.4.4",
+                f"VCEK HWID {hwid_raw.hex()} != report chip_id {report[0x1A0:0x1A0 + 64].hex()}")
+
+    # TCB cross-check: each SPL extension must match the corresponding byte
+    # of report.reported_tcb (TCBVersion decomposition per SPEC §3.4.3).
+    reported_tcb = int.from_bytes(report[0x180:0x188], "little")
+    tcb_pairs = [
+        ("bl_spl",    _AMD_OID_BL_SPL,    reported_tcb & 0xff),
+        ("tee_spl",   _AMD_OID_TEE_SPL,   (reported_tcb >> 8) & 0xff),
+        ("snp_spl",   _AMD_OID_SNP_SPL,   (reported_tcb >> 48) & 0xff),
+        ("ucode_spl", _AMD_OID_UCODE_SPL, (reported_tcb >> 56) & 0xff),
+    ]
+    for name, oid, report_val in tcb_pairs:
+        raw = ext_map.get(oid)
+        if raw is None:
+            continue
+        cert_val = _decode_int_ext_value(raw)
+        if cert_val is None:
+            continue
+        if cert_val != report_val:
+            return ("VCEK_TCB_MISMATCH", "3.4.3",
+                    f"VCEK {name}={cert_val} != report.reported_tcb.{name}={report_val}")
+    return None
+
+
+def _enforce_sev_policy(report: bytes, policy: dict[str, Any] | None) -> tuple[str, str, str] | None:
+    # SPEC §3.7 / Tinfoil-policy: migrate_ma=1 MUST be rejected. Run
+    # unconditionally — independent of fixture policy — to mirror what
+    # the lib's validate_report would have caught.
+    guest_policy_pre = int.from_bytes(report[0x08:0x10], "little")
+    if (guest_policy_pre >> 18) & 1:
+        return ("GUEST_POLICY_MIGRATE_MA_SET", "3.7",
+                f"guest_policy MIGRATE_MA bit (18) is set (policy={guest_policy_pre:016x})")
+
+    if not policy:
+        return None
+
+    measurement = report[0x90:0x90 + 48]
+    host_data = report[0xC0:0xC0 + 32]
+    report_data = report[0x50:0x90]
+    id_key_digest = report[0xE0:0xE0 + 48]
+    author_key_digest = report[0x110:0x110 + 48]
+    guest_policy = int.from_bytes(report[0x08:0x10], "little")
+    current_tcb = int.from_bytes(report[0x38:0x40], "little")
+    tcb_bl = current_tcb & 0xff
+    tcb_tee = (current_tcb >> 8) & 0xff
+    tcb_snp = (current_tcb >> 48) & 0xff
+    tcb_ucode = (current_tcb >> 56) & 0xff
+
+    pairs: list[tuple[str, str, str, bytes, str]] = [
+        ("MEASUREMENT_MISMATCH", "3.8", "measurement",
+         measurement, policy.get("expected_measurement_hex", "")),
+        ("HOST_DATA_MISMATCH", "8.3", "host_data",
+         host_data, policy.get("expected_host_data_hex", "")),
+        ("REPORT_DATA_MISMATCH", "8.2", "report_data",
+         report_data, policy.get("expected_report_data_hex", "")),
+        ("ID_KEY_DIGEST_MISMATCH", "3.1.1", "id_key_digest",
+         id_key_digest, policy.get("expected_id_key_digest_hex", "")),
+        ("AUTHOR_KEY_DIGEST_MISMATCH", "3.1.1", "author_key_digest",
+         author_key_digest, policy.get("expected_author_key_digest_hex", "")),
+    ]
+    for code, ref, name, actual, expected in pairs:
+        exp = (expected or "").strip().lower()
+        if not exp:
+            continue
+        if actual.hex() != exp:
+            return code, ref, f"{name} {actual.hex()} != policy expected {exp}"
+
+    for name, actual, min_key in (
+        ("bl_spl", tcb_bl, "min_tcb_bl_spl"),
+        ("tee_spl", tcb_tee, "min_tcb_tee_spl"),
+        ("snp_spl", tcb_snp, "min_tcb_snp_spl"),
+        ("ucode_spl", tcb_ucode, "min_tcb_ucode_spl"),
+    ):
+        m = policy.get(min_key)
+        if m is not None and actual < int(m):
+            return "TCB_OUT_OF_DATE", "3.7", f"tcb.{name}={actual} below minimum {m}"
+
+    if policy.get("enforce_spec_defaults"):
+        if (guest_policy >> 19) & 1:
+            return ("GUEST_POLICY_DEBUG_SET", "3.7",
+                    f"guest_policy DEBUG bit (19) is set (policy={guest_policy:016x})")
+        if not ((guest_policy >> 17) & 1):
+            return ("GUEST_POLICY_RESERVED_BIT_SET", "3.7",
+                    f"guest_policy reserved-MBO bit (17) is clear (policy={guest_policy:016x})")
+        if guest_policy & 0xFFFFFFFFFE000000:
+            return ("GUEST_POLICY_RESERVED_BIT_SET", "3.7",
+                    f"guest_policy reserved-MBZ bit (≥25) set (policy={guest_policy:016x})")
+    return None
+
+
+@contextlib.contextmanager
+def _maybe_override_sev_time(_timestamp: int | None):
+    """No-op for SEV on Python — the lib delegates VCEK NotBefore/NotAfter
+    to pyOpenSSL's X509Store.verify_certificate which uses the OS clock
+    via OpenSSL internals. No Python-level monkey-patch can override it.
+    Fixtures that need time injection (e.g. 240-vcek-expired) gate on
+    attestation_sev.verification_time_override=supported and skip cleanly
+    on tinfoil-python."""
+    yield
+
+
+def cmd_verify_attestation_sev() -> int:
+    try:
+        raw = sys.stdin.read()
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"input schema violation: {e}\n")
+        return EXIT_BAD_INPUT
+
+    if data.get("schema_version") != "1":
+        sys.stderr.write('schema_version must be "1"\n')
+        return EXIT_BAD_INPUT
+
+    att_doc_b64 = data.get("attestation_doc_b64")
+    vcek_b64 = data.get("vcek_der_b64")
+    if not att_doc_b64 or not vcek_b64:
+        return _emit_sev_rejection(
+            "REPORT_FORMAT_UNSUPPORTED", "3.1",
+            "attestation_doc_b64 and vcek_der_b64 are required",
+        )
+
+    # Decompress + length-check locally so REPORT_TRUNCATED surfaces before
+    # the lib's Report() constructor (which raises a generic parse error).
+    import gzip as _gzip
+    try:
+        gz_bytes = base64.standard_b64decode(att_doc_b64)
+    except Exception as e:
+        return _emit_sev_rejection(
+            "REPORT_FORMAT_UNSUPPORTED", "3.1",
+            f"attestation_doc_b64 not valid base64: {e}",
+        )
+    try:
+        report_bytes = _gzip.decompress(gz_bytes)
+    except Exception as e:
+        return _emit_sev_rejection(
+            "REPORT_FORMAT_UNSUPPORTED", "3.1",
+            f"gzip decompress failed: {e}",
+        )
+    if len(report_bytes) < _SEV_REPORT_LEN:
+        return _emit_sev_rejection(
+            "REPORT_TRUNCATED", "3.1",
+            f"SEV report is {len(report_bytes)} bytes, expected ≥{_SEV_REPORT_LEN}",
+        )
+
+    try:
+        vcek_der = base64.standard_b64decode(vcek_b64)
+    except Exception as e:
+        return _emit_sev_rejection(
+            "VCEK_CHAIN_INVALID", "3.3.3",
+            f"vcek_der_b64 not valid base64: {e}",
+        )
+
+    # Build the chain directly with the supplied VCEK + embedded ARK/ASK.
+    # Bypasses CertificateChain.from_report which would fetch VCEK from KDS.
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes  # noqa: F401
+    from ..attestation.abi_sev import Report as _Report
+    from ..attestation.verify_sev import (
+        CertificateChain, verify_attestation, ARK_CERT, ASK_CERT,
+    )
+    import warnings as _warnings
+    from cryptography.utils import CryptographyDeprecationWarning
+
+    try:
+        report = _Report(report_bytes)
+    except Exception as e:
+        code, ref = _classify_sev_error(f"failed to parse report: {e}")
+        return _emit_sev_rejection(code, ref, str(e))
+
+    # Phase 4B-SEV: if the fixture supplies synthetic ARK/ASK PEMs, parse
+    # those instead of the lib's embedded production constants. Mirrors
+    # the Go binary's TrustedRoots-injection path.
+    fixture_ark_pem = data.get("amd_root_ca_pem", "") or ""
+    fixture_ask_pem = data.get("ask_pem", "") or ""
+    try:
+        ark_pem_bytes = fixture_ark_pem.encode() if fixture_ark_pem else ARK_CERT
+        ask_pem_bytes = fixture_ask_pem.encode() if fixture_ask_pem else ASK_CERT
+        ark = x509.load_pem_x509_certificate(ark_pem_bytes)
+        ask = x509.load_pem_x509_certificate(ask_pem_bytes)
+    except Exception as e:
+        return _emit_sev_rejection(
+            "ARK_UNTRUSTED", "3.3.1",
+            f"failed to parse AMD chain (fixture-supplied={bool(fixture_ark_pem)}): {e}",
+        )
+    try:
+        with _warnings.catch_warnings():
+            _warnings.filterwarnings(
+                "ignore",
+                message=r"Parsed a serial number which wasn't positive",
+                category=CryptographyDeprecationWarning,
+            )
+            vcek = x509.load_der_x509_certificate(vcek_der)
+    except Exception as e:
+        return _emit_sev_rejection(
+            "VCEK_CHAIN_INVALID", "3.3.5",
+            f"could not interpret VCEK DER: {e}",
+        )
+
+    chain = CertificateChain(ark=ark, ask=ask, vcek=vcek)
+
+    expiration_unix = data.get("expiration_check_date_unix")
+
+    # tinfoil-python's verify_attestation / verify_chain print error
+    # diagnostics via print() to stdout when verification fails. The
+    # conformance binary's contract is JSON-only on stdout, so we capture
+    # the lib's stdout and route it to stderr.
+    import io as _io
+    captured = _io.StringIO()
+    orig_stdout = sys.stdout
+    sys.stdout = captured
+    try:
+        with _maybe_override_sev_time(expiration_unix):
+            ok = verify_attestation(chain, report)
+    except Exception as e:
+        sys.stdout = orig_stdout
+        sys.stderr.write(captured.getvalue())
+        code, ref = _classify_sev_error(str(e))
+        return _emit_sev_rejection(code, ref, str(e))
+    sys.stdout = orig_stdout
+    lib_diag = captured.getvalue()
+    if lib_diag:
+        sys.stderr.write(lib_diag)
+    if not ok:
+        # Differentiate signature vs chain failure based on captured lib
+        # output — verify_chain prints "Certificate chain verification
+        # failed" / "VCEK certificate validation failed" etc., while the
+        # report signature path prints "Attestation signature verification
+        # failed". Fall back to a generic REPORT_SIGNATURE_INVALID.
+        diag_msg = lib_diag or "verification returned False"
+        code, ref = _classify_sev_error(diag_msg)
+        if code == "QV_RESULT_TERMINAL_UNSPECIFIED":
+            code, ref = "REPORT_SIGNATURE_INVALID", "3.6"
+        return _emit_sev_rejection(code, ref, diag_msg.strip() or "verification returned False")
+
+    # Skip the lib's validate_report — its hardcoded production policy
+    # (MigrateMA=False, debug=False, smt=True, etc.) is mostly satisfied by
+    # the bundle but we instead enforce the fixture's pinned policy below,
+    # mirroring the Go binary's enforceSevPolicy.
+
+    # SPEC §3.4 mandatory: VCEK ext ↔ report cross-checks. The lib's
+    # validate_report does these but we bypass it to keep policy logic
+    # in our hands. Run before fixture policy pins so VCEK_HWID_MISMATCH /
+    # VCEK_TCB_MISMATCH surface cleanly.
+    vcek_viol = _enforce_sev_vcek_cross_checks(report_bytes, vcek)
+    if vcek_viol:
+        return _emit_sev_rejection(*vcek_viol)
+
+    pol_viol = _enforce_sev_policy(report_bytes, data.get("policy"))
+    if pol_viol:
+        return _emit_sev_rejection(*pol_viol)
+
+    body_fields = _decode_sev_body_fields(report_bytes)
+    out_body = {
+        "stage": "verify-attestation-sev",
+        "accepted": True,
+        "outputs": {
+            "measurement": {
+                "type": SEV_GUEST_V2_URI,
+                "registers": [body_fields["measurement_hex"]],
+            },
+            "body_fields": body_fields,
+        },
+    }
+    json.dump(out_body, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return EXIT_ACCEPT
+
+
 def main(argv: list[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
@@ -1130,6 +1598,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_verify_hardware_measurements()
     if sub == "verify-attestation-tdx":
         return cmd_verify_attestation_tdx()
+    if sub == "verify-attestation-sev":
+        return cmd_verify_attestation_sev()
     if sub in ("", "help", "-h", "--help"):
         _print_help()
         return EXIT_ACCEPT

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -177,6 +177,9 @@ def _capabilities() -> dict[str, Any]:
             # lands when Phase 3 fixtures need it.
             "supported": True,
             "injected_collateral_supported": True,
+            # verify-full's TDX sub-runner (_run_verify_attestation_tdx_inner)
+            # is wired, so standard/bundle-flow TDX fixtures run end-to-end.
+            "verify_full_supported": True,
             # cert_utils.verify_intel_chain et al. call datetime.now()
             # unconditionally — the lib has no public time-injection API.
             # cmd_verify_attestation_tdx works around this by monkey-
@@ -2073,6 +2076,63 @@ def _classify_measurement_compare_error(e: Exception) -> tuple[str, str]:
     return "MEASUREMENT_MISMATCH", "7.3"
 
 
+def _run_verify_attestation_tdx_inner(
+    inp: dict[str, Any],
+) -> "Measurement | tuple[str, str, str]":
+    """Inner TDX verification — shared by cmd_verify_full. Verifies the quote the
+    same way the standalone verify-attestation-tdx stage does (parse +
+    verify_tdx_quote_crypto + collateral evaluation + extended-TD policy) and
+    returns a TdxGuestV2 Measurement on success, or an (code, spec_ref, message)
+    tuple on failure."""
+    try:
+        quote_bytes = base64.b64decode(inp["quote_b64"])
+    except Exception as e:
+        return ("QUOTE_FORMAT_UNSUPPORTED", "A.3", f"quote_b64 not valid base64: {e}")
+    try:
+        quote = parse_tdx_quote(quote_bytes)
+    except Exception as e:
+        code, ref = _classify_tdx_error(e)
+        return (code, ref, str(e))
+
+    policy = inp.get("policy") or {}
+    tcb_eval_required = policy.get("tcb_evaluation_required", True)
+    collateral_in = inp.get("collateral") or {}
+    custom_root_pem = collateral_in.get("intel_root_ca_pem")
+    fixture_date = inp.get("expiration_check_date_unix")
+    with _maybe_override_intel_root(custom_root_pem), _maybe_override_time(fixture_date):
+        try:
+            pck_chain = verify_tdx_quote_crypto(quote, quote_bytes)
+        except TdxVerificationError as e:
+            code, ref = _classify_tdx_error(e)
+            return (code, ref, str(e))
+        except Exception as e:
+            code, ref = _classify_tdx_error(e)
+            return (code, ref, f"unexpected: {e}")
+
+        if tcb_eval_required:
+            code, ref, msg = _evaluate_collateral(
+                quote, pck_chain, collateral_in, fixture_date, policy
+            )
+            if code:
+                return (code, ref, msg)
+
+    code, msg = _enforce_extended_policy(quote_bytes, policy)
+    if code:
+        return (code, "4.8", msg)
+
+    body = quote.td_quote_body
+    return Measurement(
+        type=PredicateType.TDX_GUEST_V2,
+        registers=[
+            body.mr_td.hex(),
+            body.rtmrs[0].hex(),
+            body.rtmrs[1].hex(),
+            body.rtmrs[2].hex(),
+            body.rtmrs[3].hex(),
+        ],
+    )
+
+
 def cmd_verify_full() -> int:
     try:
         raw = sys.stdin.read()
@@ -2104,17 +2164,26 @@ def cmd_verify_full() -> int:
         sig_measurement = sig_result.measurement
 
         sev_in = data.get("attestation_sev")
-        if not isinstance(sev_in, dict):
+        tdx_in = data.get("attestation_tdx")
+        if isinstance(sev_in, dict):
+            platform = "sev-snp"
+            sev_result = _run_verify_attestation_sev_inner(sev_in)
+            if isinstance(sev_result[0], str):
+                code, spec_ref, msg = sev_result  # type: ignore[misc]
+                return _emit_full_rejection(code, "verify-attestation-sev", spec_ref, msg)
+            att_measurement, _report, _body = sev_result
+        elif isinstance(tdx_in, dict):
+            platform = "tdx"
+            tdx_result = _run_verify_attestation_tdx_inner(tdx_in)
+            if isinstance(tdx_result, tuple):
+                code, spec_ref, msg = tdx_result
+                return _emit_full_rejection(code, "verify-attestation-tdx", spec_ref, msg)
+            att_measurement = tdx_result
+        else:
             return _emit_full_rejection(
                 "BUNDLE_MALFORMED", "verify-full", "11.1",
-                'mode="standard"/"bundle" requires attestation_sev '
-                "(TDX path not wired yet on Python)",
+                'mode="standard"/"bundle" requires attestation_sev or attestation_tdx',
             )
-        sev_result = _run_verify_attestation_sev_inner(sev_in)
-        if isinstance(sev_result[0], str):
-            code, spec_ref, msg = sev_result  # type: ignore[misc]
-            return _emit_full_rejection(code, "verify-attestation-sev", spec_ref, msg)
-        att_measurement, _report, _body = sev_result
 
         try:
             sig_measurement.assert_equal(att_measurement)
@@ -2128,7 +2197,7 @@ def cmd_verify_full() -> int:
             "accepted": True,
             "outputs": {
                 "mode": mode,
-                "platform": "sev-snp",
+                "platform": platform,
                 "sigstore_measurement": {
                     "type": sig_measurement.type.value
                     if hasattr(sig_measurement.type, "value")

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -121,6 +121,17 @@ def _capabilities() -> dict[str, Any]:
         "measurement": {
             "compare_multiplatform_to_tdx_supported": True,
         },
+        "attestation_tdx": {
+            # tinfoil-python has a deep native TDX verifier
+            # (tinfoil.attestation.verify_tdx) but its public API doesn't
+            # currently expose a collateral-injection entry point — it
+            # fetches from Intel PCS. Conformance support lands in Phase 1.5
+            # once we wrap verify_tdx with an injected-collateral path;
+            # declared false here so attestation-tdx fixtures skip cleanly
+            # until then.
+            "supported": False,
+            "injected_collateral_supported": False,
+        },
         "platforms_supported": ["sev-snp", "tdx"],
         "transport_modes_supported": ["tls-pinning"],
         "flow_modes_supported": ["standard"],

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -230,8 +230,14 @@ def _capabilities() -> dict[str, Any]:
             "amd_root_ca_injection_supported": True,
         },
         "platforms_supported": ["sev-snp", "tdx"],
-        "transport_modes_supported": ["tls-pinning"],
-        "flow_modes_supported": ["standard", "pinned"],
+        # EHBP (Encrypted HTTP Body Protocol) transport is implemented in the
+        # SDK and is the default — see client.py (_EHBPReVerifyingTransport,
+        # make_secure_http_client). No fixture gates on transport today; this
+        # declares library capability. "bundle" flow: cmd_verify_full accepts
+        # bundle mode and the SDK ships a full bundle pipeline (attestation/
+        # bundle.py, client.verify_from_bundle).
+        "transport_modes_supported": ["tls-pinning", "ehbp"],
+        "flow_modes_supported": ["standard", "bundle", "pinned"],
         "known_quirks": {
             "sigstore.workflow_ref_check_via_startswith":
                 "We replaced sigstore.verify.policy's regex-based GitHubWorkflowRefPattern with a strict-prefix startswith() check (SPEC §5.3 reads as prefix, not regex).",

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -1,0 +1,388 @@
+"""tinfoil-conformance CLI entry point for tinfoil-python.
+
+Subcommands:
+    tinfoil-conformance capabilities                # stdin: none, stdout: JSON
+    tinfoil-conformance verify-sigstore             # stdin: JSON, stdout: JSON
+
+Exit codes:
+    0   accepted
+    10  rejected (rejection.code populated)
+    20  stage/capability not supported
+    30  malformed input
+    1   internal error
+
+See tinfoil-conformance/schemas/ for the I/O schemas.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from typing import Any, Tuple
+
+from ..sigstore import (
+    SigstorePolicy,
+    SigstoreVerification,
+    default_sigstore_policy,
+    verify_sigstore_bundle_with_policy,
+)
+
+
+EXIT_ACCEPT = 0
+EXIT_REJECT = 10
+EXIT_UNSUPPORTED = 20
+EXIT_BAD_INPUT = 30
+EXIT_INTERNAL = 1
+
+SDK_NAME = "tinfoil-python"
+
+
+def _sdk_version() -> str:
+    try:
+        from importlib.metadata import version
+        return version("tinfoil")
+    except Exception:
+        return "0.0.0"
+
+
+def _capabilities() -> dict[str, Any]:
+    """Self-description for the conformance harness. Keep
+    `stages_supported` honest — fixtures targeting stages not listed
+    here are auto-skipped by the harness."""
+    return {
+        "schema_version": "1",
+        "sdk": SDK_NAME,
+        "sdk_version": _sdk_version(),
+        "stages_supported": ["verify-sigstore"],
+        "sigstore": {
+            "trust_root_loading": "configurable",
+            # `sigstore` 4.2 verifies cert chain validity against the
+            # cert.NotBefore from the bundle, not the system clock.
+            # Hermetic on system clock; the supplied verification_time_unix
+            # parameter isn't currently consulted.
+            "verification_time_override": "bundle-supplied-only",
+            "policy_fields_configurable": {
+                "oidc_issuer": True,
+                "workflow_ref_prefix": True,
+                "workflow_repository": True,
+                "predicate_types_allowed": True,
+                "in_toto_statement_types_allowed": True,
+                "payload_type": True,
+                # The sigstore PyPI lib hardcodes minimum tlog/sct/observer
+                # thresholds (== 1). Not configurable through its public
+                # API today.
+                "tlog_entries_min": False,
+                "tlog_entries_max": False,
+                "sct_min": False,
+                "observer_timestamps_min": False,
+            },
+            "predicate_types_understood": [
+                "https://tinfoil.sh/predicate/snp-tdx-multiplatform/v1",
+            ],
+            # sigstore-python 4.x normalizes bundles via Bundle.from_json
+            # which only accepts the v0.3 mediaType; the older
+            # x509CertificateChain layout would need conversion before load.
+            "legacy_bundle_format_supported": False,
+            # sigstore-python hardcodes len(tlog_entries) == 1.
+            "accepts_multi_tlog_entries": False,
+            # sigstore-python's policy.OIDCIssuer reads V1 (.1.1) before V2.
+            "oidc_issuer_v2_preferred": False,
+            # sigstore-python collapses missing-SCT and duplicate-SCT into
+            # the same "Expected one certificate timestamp" error.
+            "scts_count_distinguish_missing_vs_duplicate": False,
+        },
+        "platforms_supported": ["sev-snp", "tdx"],
+        "transport_modes_supported": ["tls-pinning"],
+        "flow_modes_supported": ["standard"],
+        "known_quirks": {
+            "sigstore.workflow_ref_check_via_startswith":
+                "We replaced sigstore.verify.policy's regex-based GitHubWorkflowRefPattern with a strict-prefix startswith() check (SPEC §5.3 reads as prefix, not regex).",
+            "sigstore.lib_pyca_sigstore":
+                "Verification delegated to the sigstore PyPI package; only its public API surface is exercised.",
+        },
+    }
+
+
+def _emit_accept(v: SigstoreVerification) -> int:
+    body = {
+        "stage": "verify-sigstore",
+        "accepted": True,
+        "outputs": {
+            "predicate_type": v.predicate_type,
+            "in_toto_statement_type": v.in_toto_statement_type,
+            "subject_name": v.subject_name,
+            "subject_digest_sha256_hex": v.subject_digest_sha256_hex,
+            "measurement": {
+                # Measurement.type is a PredicateType enum whose .value is
+                # the canonical URI. Match the Rust/JS output shape.
+                "type": v.measurement.type.value
+                if hasattr(v.measurement.type, "value")
+                else str(v.measurement.type),
+                "registers": v.measurement.registers,
+            },
+            "cert_oidc_issuer": v.cert_oidc_issuer,
+            "cert_workflow_repository": v.cert_workflow_repository,
+            "cert_workflow_signer_uri": v.cert_workflow_signer_uri,
+            "rekor_log_id_hex": v.rekor_log_id_hex,
+            "rekor_integrated_time_unix": v.rekor_integrated_time_unix,
+            "tlog_entry_count": v.tlog_entry_count,
+            "sct_count": v.sct_count,
+        },
+    }
+    json.dump(body, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return EXIT_ACCEPT
+
+
+def _emit_rejection(code: str, spec_ref: str, message: str, exit_code: int) -> int:
+    body = {
+        "stage": "verify-sigstore",
+        "accepted": False,
+        "rejection": {"code": code, "spec_ref": spec_ref, "message": message},
+    }
+    json.dump(body, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return exit_code
+
+
+# Stable rejection-code prefixes the verifier helpers emit. Order matters —
+# most specific first (e.g. CERT_EXPIRED before generic FULCIO_CHAIN_INVALID).
+_PREFIX_MAP: list[tuple[str, str, str]] = [
+    ("TLOG_COUNT_OUT_OF_RANGE:", "TLOG_COUNT_OUT_OF_RANGE", "5.2"),
+    ("OIDC_ISSUER_MISMATCH:", "OIDC_ISSUER_MISMATCH", "5.3"),
+    ("WORKFLOW_REPOSITORY_MISMATCH:", "WORKFLOW_REPOSITORY_MISMATCH", "5.3"),
+    ("WORKFLOW_REF_PREFIX_MISMATCH:", "WORKFLOW_REF_PREFIX_MISMATCH", "5.3"),
+    ("PAYLOAD_TYPE_MISMATCH:", "PAYLOAD_TYPE_MISMATCH", "5.4"),
+    ("IN_TOTO_STATEMENT_TYPE_NOT_ALLOWED:", "IN_TOTO_STATEMENT_TYPE_NOT_ALLOWED", "5.4"),
+    ("PREDICATE_TYPE_NOT_ALLOWED:", "PREDICATE_TYPE_NOT_ALLOWED", "5.5"),
+    ("SUBJECT_DIGEST_MISMATCH:", "SUBJECT_DIGEST_MISMATCH", "5.4"),
+    ("SUBJECT_MISSING:", "SUBJECT_MISSING", "5.4"),
+    ("PREDICATE_MEASUREMENT_INVALID:", "PREDICATE_MEASUREMENT_INVALID", "5.5"),
+    ("BUNDLE_MALFORMED:", "BUNDLE_MALFORMED", "5.2"),
+]
+
+
+def _classify(message: str) -> Tuple[str, str]:
+    """Map a verification-failure message string to a (rejection_code,
+    spec_ref) pair. The verifier's policy-driven helpers lead with stable
+    code prefixes; sigstore-python's own VerificationError messages come
+    through unprefixed and need substring matching.
+
+    Order matters — most specific patterns first.
+    """
+    for prefix, code, spec_ref in _PREFIX_MAP:
+        if message.startswith(prefix) or prefix in message:
+            return (code, spec_ref)
+    low = message.lower()
+
+    # sigstore-python's `policy.OIDCIssuer.verify` raises with a stable
+    # English message form. Catch it before generic patterns.
+    if "oidcissuer does not match" in low or "oidc issuer does not match" in low:
+        return ("OIDC_ISSUER_MISMATCH", "5.3")
+    if "githubworkflowrepository does not match" in low:
+        return ("WORKFLOW_REPOSITORY_MISMATCH", "5.3")
+    if "githubworkflowref" in low and (
+        "does not match" in low or "does not contain" in low
+    ):
+        return ("WORKFLOW_REF_PREFIX_MISMATCH", "5.3")
+
+    # CERT_EXPIRED catches both "outside cert validity" (Rust phrasing) and
+    # "certificate has expired" (sigstore-python's certvalidator phrasing).
+    if (
+        ("outside" in low and "validity" in low)
+        or "certificate has expired" in low
+        or "certificate is expired" in low
+    ):
+        return ("CERT_EXPIRED", "5.2")
+
+    # SCT count: sigstore-python emits "Expected one certificate timestamp"
+    # for both zero-SCT and N-SCT cases (it doesn't distinguish duplicate
+    # from missing). Bucket as SCT_INSUFFICIENT — the fixture for duplicate
+    # SCTs (066) accepts a list including this code when running on Python.
+    if "certificate timestamp" in low and (
+        "expected" in low or "one" in low
+    ):
+        return ("SCT_INSUFFICIENT", "5.2")
+    if "duplicate sct" in low or ("duplicate" in low and "sct" in low):
+        return ("SCT_DUPLICATE_LOG", "5.2")
+    if "sct" in low and (
+        "no valid" in low or "missing" in low or "no sct" in low or "no scts" in low
+    ):
+        return ("SCT_INSUFFICIENT", "5.2")
+
+    # Trust root with no Fulcio CAs — sigstore-python's TrustedRoot raises
+    # "Fulcio certificates not found in trusted root". This is a chain
+    # failure (no CA = can't verify the chain), bucket as FULCIO_CHAIN_INVALID
+    # to match Rust/JS canonical mapping.
+    if "fulcio certificates not found" in low or "no fulcio" in low:
+        return ("FULCIO_CHAIN_INVALID", "5.2")
+
+    # sigstore-python raises a bare IndexError ("list index out of range")
+    # when the trust root has no tlogs — internal bug, but the symptom is
+    # "no Rekor key to look up against", semantically REKOR_KEY_NOT_TRUSTED.
+    if "list index out of range" in low:
+        return ("REKOR_KEY_NOT_TRUSTED", "5.1")
+
+    # Inclusion proof / checkpoint / rekor — order before the generic
+    # "log entry" tlog-count check so "inclusion proof contains invalid
+    # root hash" (sigstore-python's phrasing) gets the right code.
+    if "inclusion proof" in low and ("invalid" in low or "root hash" in low):
+        return ("REKOR_INCLUSION_INVALID", "5.2")
+    if "rekor" in low or "checkpoint" in low:
+        return ("REKOR_INCLUSION_INVALID", "5.2")
+
+    # sigstore-python hardcodes `len(tlog_entries) == 1`, emits
+    # "expected exactly one log entry". Map to TLOG_COUNT_OUT_OF_RANGE.
+    if "expected exactly one log entry" in low or "expected one log entry" in low:
+        return ("TLOG_COUNT_OUT_OF_RANGE", "5.2")
+    if "tlog" in low or "log entry" in low or "log entries" in low:
+        return ("TLOG_COUNT_OUT_OF_RANGE", "5.2")
+
+    if "trust root" in low or "trusted root" in low:
+        return ("TRUST_ROOT_INVALID", "5.1")
+    if "fulcio" in low or "certificate chain" in low or "no valid ca" in low:
+        return ("FULCIO_CHAIN_INVALID", "5.2")
+    # sigstore-python's pydantic validation message for a bundle missing
+    # both DSSE envelope and message signature.
+    if "exactly one of messagesignature or dsseenvelope" in low or (
+        "dsseenvelope" in low and "must be set" in low
+    ):
+        return ("BUNDLE_MALFORMED", "5.2")
+    if "signature" in low and (
+        "invalid" in low or "verification" in low or "failed" in low
+    ):
+        return ("DSSE_SIGNATURE_INVALID", "5.2")
+    return ("BUNDLE_MALFORMED", "5.2")
+
+
+def cmd_verify_sigstore() -> int:
+    """Read stdin JSON, run verify_sigstore_bundle_with_policy, emit output."""
+    try:
+        raw = sys.stdin.read()
+    except Exception as e:
+        sys.stderr.write(f"error reading stdin: {e}\n")
+        return EXIT_INTERNAL
+
+    try:
+        inp = json.loads(raw)
+    except json.JSONDecodeError as e:
+        return _emit_rejection(
+            "BUNDLE_MALFORMED",
+            "5.2",
+            f"input is not valid JSON: {e}",
+            EXIT_BAD_INPUT,
+        )
+
+    if inp.get("schema_version") != "1":
+        return _emit_rejection(
+            "BUNDLE_MALFORMED",
+            "5.2",
+            'input.schema_version != "1"',
+            EXIT_BAD_INPUT,
+        )
+
+    try:
+        bundle_bytes = base64.b64decode(inp["bundle_b64"])
+    except Exception as e:
+        return _emit_rejection(
+            "BUNDLE_MALFORMED",
+            "5.2",
+            f"bundle_b64 not valid base64: {e}",
+            EXIT_BAD_INPUT,
+        )
+
+    try:
+        trust_root_bytes = base64.b64decode(inp["trust_root_b64"])
+    except Exception as e:
+        return _emit_rejection(
+            "TRUST_ROOT_INVALID",
+            "5.1",
+            f"trust_root_b64 not valid base64: {e}",
+            EXIT_BAD_INPUT,
+        )
+    try:
+        trust_root_json = trust_root_bytes.decode("utf-8")
+    except UnicodeDecodeError as e:
+        return _emit_rejection(
+            "TRUST_ROOT_INVALID",
+            "5.1",
+            f"trust_root is not valid UTF-8: {e}",
+            EXIT_REJECT,
+        )
+
+    policy_in = inp.get("policy") or {}
+    defaults = default_sigstore_policy(inp.get("repo", ""))
+    policy = SigstorePolicy(
+        oidc_issuer=policy_in.get("oidc_issuer", defaults.oidc_issuer),
+        workflow_ref_prefix=policy_in.get(
+            "workflow_ref_prefix", defaults.workflow_ref_prefix
+        ),
+        workflow_repository=inp["repo"],
+        predicate_types_allowed=(
+            policy_in["predicate_types_allowed"]
+            if "predicate_types_allowed" in policy_in
+            else defaults.predicate_types_allowed
+        ),
+        in_toto_statement_types_allowed=(
+            policy_in["in_toto_statement_types_allowed"]
+            if "in_toto_statement_types_allowed" in policy_in
+            else defaults.in_toto_statement_types_allowed
+        ),
+        payload_type=policy_in.get("payload_type", defaults.payload_type),
+    )
+
+    try:
+        v = verify_sigstore_bundle_with_policy(
+            bundle_bytes=bundle_bytes,
+            expected_digest_sha256_hex=inp["expected_digest_sha256_hex"],
+            policy=policy,
+            trust_root_json=trust_root_json,
+        )
+    except Exception as e:
+        # Walk the exception chain; sigstore's VerificationError may be
+        # wrapped by our ValueError. Concatenate messages so the classifier
+        # sees the most specific text.
+        parts = []
+        cur: BaseException | None = e
+        while cur is not None and len(parts) < 8:
+            parts.append(str(cur))
+            cur = cur.__cause__
+        message = " | ".join(parts)
+        code, spec_ref = _classify(message)
+        return _emit_rejection(code, spec_ref, message, EXIT_REJECT)
+
+    return _emit_accept(v)
+
+
+def _print_help() -> None:
+    sys.stderr.write(
+        "tinfoil-conformance: Tinfoil cross-SDK conformance binary "
+        f"({SDK_NAME} {_sdk_version()})\n\n"
+        "Subcommands:\n"
+        "  capabilities      Print SDK capabilities JSON\n"
+        "  verify-sigstore   Verify a Sigstore bundle (SPEC §5)\n\n"
+        "I/O contract: stdin JSON, stdout JSON. See tinfoil-conformance/schemas/.\n"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+    sub = argv[0] if argv else ""
+    if sub == "capabilities":
+        json.dump(_capabilities(), sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+        return EXIT_ACCEPT
+    if sub == "verify-sigstore":
+        return cmd_verify_sigstore()
+    if sub in ("", "help", "-h", "--help"):
+        _print_help()
+        return EXIT_ACCEPT
+    sys.stderr.write(f"tinfoil-conformance: unknown subcommand {sub!r}\n")
+    _print_help()
+    return EXIT_BAD_INPUT
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -21,6 +21,16 @@ import json
 import sys
 from typing import Any, Tuple
 
+from ..attestation.types import (
+    FormatMismatchError,
+    Measurement,
+    MeasurementMismatchError,
+    PredicateType,
+    Rtmr3NotZeroError,
+    MULTIPLATFORM_REGISTER_COUNT,
+    SEV_REGISTER_COUNT,
+    TDX_REGISTER_COUNT,
+)
 from ..sigstore import (
     SigstorePolicy,
     SigstoreVerification,
@@ -54,7 +64,7 @@ def _capabilities() -> dict[str, Any]:
         "schema_version": "1",
         "sdk": SDK_NAME,
         "sdk_version": _sdk_version(),
-        "stages_supported": ["verify-sigstore"],
+        "stages_supported": ["verify-sigstore", "verify-measurement"],
         "sigstore": {
             "trust_root_loading": "configurable",
             # `sigstore` 4.2 verifies cert chain validity against the
@@ -100,6 +110,9 @@ def _capabilities() -> dict[str, Any]:
             # sigstore-python's in-toto parser tolerates extra top-level
             # fields (pydantic's extra=allow on the statement model).
             "in_toto_statement_tolerates_extra_fields": True,
+        },
+        "measurement": {
+            "compare_multiplatform_to_tdx_supported": True,
         },
         "platforms_supported": ["sev-snp", "tdx"],
         "transport_modes_supported": ["tls-pinning"],
@@ -375,6 +388,116 @@ def _print_help() -> None:
     )
 
 
+# -----------------------------------------------------------------------------
+# verify-measurement (SPEC §7)
+# -----------------------------------------------------------------------------
+
+_EXPECTED_REGISTER_COUNT = {
+    PredicateType.SEV_GUEST_V2: SEV_REGISTER_COUNT,
+    PredicateType.TDX_GUEST_V2: TDX_REGISTER_COUNT,
+    PredicateType.SNP_TDX_MULTIPLATFORM_v1: MULTIPLATFORM_REGISTER_COUNT,
+}
+
+
+def _parse_predicate_type(uri: str) -> PredicateType | None:
+    for pt in PredicateType:
+        if pt.value == uri:
+            return pt
+    return None
+
+
+def _normalize_measurement(m: dict[str, Any]) -> Tuple[Measurement | None, str, str]:
+    """Validate type + register count and lowercase-normalize registers per
+    SPEC §7.3. Returns (measurement, code, spec_ref); on success code/spec_ref
+    are empty strings."""
+    t = _parse_predicate_type(m.get("type", ""))
+    if t is None:
+        return None, "MEASUREMENT_TYPE_UNKNOWN", "2.3"
+    expected = _EXPECTED_REGISTER_COUNT.get(t)
+    regs = m.get("registers", [])
+    if expected is None or not isinstance(regs, list) or len(regs) != expected:
+        return None, "MEASUREMENT_REGISTER_COUNT_INVALID", "7.1"
+    normalized = [r.lower() for r in regs]
+    return Measurement(type=t, registers=normalized), "", ""
+
+
+def _emit_measurement_rejection(code: str, spec_ref: str, message: str) -> int:
+    body = {
+        "stage": "verify-measurement",
+        "accepted": False,
+        "rejection": {
+            "code": code,
+            "spec_ref": spec_ref,
+            "message": message,
+        },
+    }
+    json.dump(body, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return EXIT_REJECT
+
+
+def cmd_verify_measurement() -> int:
+    raw = sys.stdin.read()
+    try:
+        inp = json.loads(raw)
+    except Exception as e:
+        sys.stderr.write(f"input schema violation: {e}\n")
+        return EXIT_BAD_INPUT
+    if inp.get("schema_version") != "1":
+        sys.stderr.write('schema_version must be "1"\n')
+        return EXIT_BAD_INPUT
+
+    source_in = inp.get("source")
+    if not isinstance(source_in, dict):
+        return _emit_measurement_rejection(
+            "MEASUREMENT_TYPE_UNKNOWN", "7", "missing source measurement"
+        )
+    source, code, spec_ref = _normalize_measurement(source_in)
+    if source is None:
+        return _emit_measurement_rejection(code, spec_ref, "source measurement invalid")
+
+    target = None
+    target_in = inp.get("target")
+    if target_in is not None:
+        target, code, spec_ref = _normalize_measurement(target_in)
+        if target is None:
+            return _emit_measurement_rejection(
+                code, spec_ref, "target measurement invalid"
+            )
+
+    source_fp = source.fingerprint()
+    target_fp = target.fingerprint() if target is not None else None
+
+    if target is not None:
+        try:
+            source.assert_equal(target)
+        except Rtmr3NotZeroError as e:
+            return _emit_measurement_rejection(
+                "MEASUREMENT_RTMR3_NONZERO", "7.3.2", str(e)
+            )
+        except MeasurementMismatchError as e:
+            return _emit_measurement_rejection(
+                "MEASUREMENT_MISMATCH", "7.3", str(e) or "registers mismatch"
+            )
+        except FormatMismatchError as e:
+            return _emit_measurement_rejection(
+                "MEASUREMENT_TYPE_COMBINATION_UNSUPPORTED", "7.3.5",
+                str(e) or "incompatible measurement types",
+            )
+
+    body = {
+        "stage": "verify-measurement",
+        "accepted": True,
+        "outputs": {
+            "source_fingerprint_hex": source_fp,
+            "target_fingerprint_hex": target_fp,
+        },
+    }
+    json.dump(body, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return EXIT_ACCEPT
+
+
 def main(argv: list[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
@@ -385,6 +508,8 @@ def main(argv: list[str] | None = None) -> int:
         return EXIT_ACCEPT
     if sub == "verify-sigstore":
         return cmd_verify_sigstore()
+    if sub == "verify-measurement":
+        return cmd_verify_measurement()
     if sub in ("", "help", "-h", "--help"):
         _print_help()
         return EXIT_ACCEPT

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -756,6 +756,42 @@ def _classify_tdx_error(err: Exception) -> Tuple[str, str]:
     if "tcb status" in msg or "no matching tcb" in msg or "tcb is revoked" in msg:
         return "TCB_REVOKED", "4.7.7"
 
+    # SPEC §4.8 extended-TD policy validation, as surfaced by the lib's
+    # validate_tdx_policy in the full (public) path. (In the adapter path these
+    # codes come from _enforce_extended_policy instead.) Messages look like
+    # "Policy validation failed: TD_ATTRIBUTES 0x1: DEBUG bit must not be set"
+    # or "Unauthorized XFAM 0x2: FIXED1 0x3 bits are unset".
+    if "td_attributes" in msg and "debug" in msg:
+        return "TD_ATTRIBUTES_DEBUG_SET", "4.8"
+    if "td_attributes" in msg and "expected" in msg:
+        return "TD_ATTRIBUTES_MISMATCH", "4.8"
+    if "td_attributes" in msg:
+        return "TD_ATTRIBUTES_RESERVED_BIT_SET", "4.8"
+    if "xfam" in msg and "fixed1" in msg:
+        return "XFAM_REQUIRED_BIT_CLEAR", "4.8"
+    if "xfam" in msg:
+        return "XFAM_FORBIDDEN_BIT_SET", "4.8"
+
+    # Collateral field-mismatch / CRL-signature checks reached in the full
+    # (public) path. These mention "qe report" / "fmspc" / "root ... crl" and
+    # must be classified before the generic qe-report-signature / pck-chain /
+    # signature patterns below.
+    if ("qe report" in msg or "qe_report" in msg) and (
+        "mrsigner" in msg or "mr_signer" in msg
+    ):
+        return "QE_IDENTITY_MRSIGNER_MISMATCH", "4.7.9"
+    if ("qe report" in msg or "qe_report" in msg) and (
+        "isv prodid" in msg or "isvprodid" in msg or "prod id" in msg
+        or "miscselect" in msg or "attributes" in msg
+    ):
+        return "QE_IDENTITY_FIELD_MISMATCH", "4.7.9"
+    if "fmspc" in msg and "mismatch" in msg:
+        return "PCK_FMSPC_MISMATCH", "4.7.2"
+    if ("root ca crl" in msg or "root crl" in msg or ("root" in msg and "crl" in msg)) and (
+        "signature" in msg or "sig " in msg or "verif" in msg
+    ):
+        return "ROOT_CA_UNTRUSTED", "4.7.4"
+
     # Quote header / structural parse failures
     if "invalid tee type" in msg or "tee type" in msg:
         return "WRONG_TEE_TYPE", "A.3.1"
@@ -1291,6 +1327,24 @@ def _cmd_verify_attestation_tdx_public(inp: dict[str, Any], policy: dict[str, An
         config_kwargs["min_tcb_evaluation_data_number"] = int(
             policy["min_tcb_evaluation_data_number"]
         )
+    else:
+        # Synthetic collateral's tcbEvaluationDataNumber is below the lib's
+        # production minimum; the adapter passes 0 so this gate doesn't fire
+        # for vectors not testing it. Fixture 346 pins a minimum (above).
+        config_kwargs["min_tcb_evaluation_data_number"] = 0
+    # The lib's policy baseline (expected_td_attributes/xfam/tee_tcb_svn/
+    # mr_seams) targets production Tinfoil enclaves and would reject these
+    # synthetic vectors at the baseline gate before the fixture's targeted
+    # check. Re-baseline to the quote's own values; the fixture's SPEC §4.8
+    # pins are then enforced precisely by _enforce_extended_policy below.
+    try:
+        _tb = parse_tdx_quote(base64.b64decode(inp["quote_b64"])).td_quote_body
+        config_kwargs.setdefault("expected_td_attributes", _tb.td_attributes)
+        config_kwargs.setdefault("expected_xfam", _tb.xfam)
+        config_kwargs.setdefault("expected_minimum_tee_tcb_svn", _tb.tee_tcb_svn)
+        config_kwargs.setdefault("accepted_mr_seams", (_tb.mr_seam,))
+    except Exception:
+        pass
 
     with (
         _maybe_override_intel_root(custom_root_pem),
@@ -1314,6 +1368,30 @@ def _cmd_verify_attestation_tdx_public(inp: dict[str, Any], policy: dict[str, An
     code, msg = _enforce_extended_policy(quote_bytes, policy)
     if code:
         return _emit_tdx_rejection(code, "4.8", msg)
+
+    # SPEC §4.7.7 policy gate: the verifier accepts non-terminal TCB statuses
+    # (SWHardeningNeeded, etc.) by default, but a fixture policy may restrict
+    # accepted_qv_results. The verifier doesn't apply caller QV-result policy,
+    # so enforce it here against the matched TCB level (mirrors the adapter).
+    accepted_qv_results = (policy or {}).get("accepted_qv_results")
+    if accepted_qv_results:
+        _tcb_status_to_qv_result = {
+            "UpToDate": "OK",
+            "SWHardeningNeeded": "SW_HARDENING_NEEDED",
+            "ConfigurationNeeded": "CONFIG_NEEDED",
+            "ConfigurationAndSWHardeningNeeded": "CONFIG_AND_SW_HARDENING_NEEDED",
+            "OutOfDate": "OUT_OF_DATE",
+            "OutOfDateConfigurationNeeded": "OUT_OF_DATE_CONFIG_NEEDED",
+            "Revoked": "REVOKED",
+        }
+        _st = getattr(result.tcb_level, "tcb_status", None)
+        tcb_status = str(getattr(_st, "value", _st))
+        qv_result = _tcb_status_to_qv_result.get(tcb_status, tcb_status)
+        if qv_result not in set(accepted_qv_results):
+            return _emit_tdx_rejection(
+                "QV_RESULT_NOT_ACCEPTED_BY_POLICY", "4.7.7",
+                f"qv_result {qv_result} from TCB status {tcb_status} "
+                f"not in accepted_qv_results {accepted_qv_results}")
 
     json.dump(_tdx_acceptance_output(result.quote), sys.stdout, indent=2, sort_keys=True)
     sys.stdout.write("\n")

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -164,11 +164,13 @@ def _capabilities() -> dict[str, Any]:
             # lands when Phase 3 fixtures need it.
             "supported": True,
             "injected_collateral_supported": True,
-            # cert_utils.verify_intel_chain calls datetime.now(timezone.utc)
-            # unconditionally — there's no API to inject the verification
-            # time. Fixtures that pin expiration_check_date outside the real-
-            # now window (e.g. 324-pck-leaf-expired) skip honestly.
-            "verification_time_override": "system-clock-only",
+            # cert_utils.verify_intel_chain et al. call datetime.now()
+            # unconditionally — the lib has no public time-injection API.
+            # cmd_verify_attestation_tdx works around this by monkey-
+            # patching the module-level datetime for the duration of
+            # verification, so functionally the conformance binary
+            # honors policy.expiration_check_date_unix end-to-end.
+            "verification_time_override": "supported",
             # Phase 2B/3 wired: cmd_verify_attestation_tdx now orchestrates
             # the lib's pure validation functions (verify_tcb_info_signature
             # + verify_qe_identity_signature + check_collateral_freshness +
@@ -959,6 +961,28 @@ def _enforce_extended_policy(
         if not any(got_hex == entry.strip().lower() for entry in allowlist):
             return ("MR_SEAM_NOT_ALLOWED",
                     f"mr_seam {got_hex} not in policy allowlist ({len(allowlist)} entries)")
+
+    # SPEC §4.8.1 / §4.8.2 normative defaults — applied regardless of pin
+    # presence when enforce_spec_defaults=true.
+    if policy.get("enforce_spec_defaults"):
+        TD_ATTR_DEBUG  = 1 << 0
+        TD_ATTR_FIXED0 = (1 << 0) | (1 << 28) | (1 << 30) | (1 << 63)
+        XFAM_FIXED1    = 0x3
+        XFAM_FIXED0    = 0x6DBE7
+        td_attr_int = int.from_bytes(td_attrs, byteorder="little")
+        if td_attr_int & TD_ATTR_DEBUG:
+            return ("TD_ATTRIBUTES_DEBUG_SET",
+                    f"TD Attributes DEBUG bit is set (td_attributes={td_attrs.hex()})")
+        if td_attr_int & ~TD_ATTR_FIXED0:
+            return ("TD_ATTRIBUTES_RESERVED_BIT_SET",
+                    f"TD Attributes has bit(s) outside FIXED0 set (td_attributes={td_attrs.hex()})")
+        xfam_int = int.from_bytes(xfam, byteorder="little")
+        if (xfam_int & XFAM_FIXED1) != XFAM_FIXED1:
+            return ("XFAM_REQUIRED_BIT_CLEAR",
+                    f"XFAM required bits 0 (FP) + 1 (SSE) not both set (xfam={xfam.hex()})")
+        if xfam_int & ~XFAM_FIXED0:
+            return ("XFAM_FORBIDDEN_BIT_SET",
+                    f"XFAM has bit(s) outside FIXED0 set (xfam={xfam.hex()})")
 
     # Min TEE_TCB_SVN — component-wise comparison (SPEC §4.8.7).
     min_hex = policy.get("min_tee_tcb_svn_hex")

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -145,6 +145,12 @@ def _capabilities() -> dict[str, Any]:
             # time. Fixtures that pin expiration_check_date outside the real-
             # now window (e.g. 324-pck-leaf-expired) skip honestly.
             "verification_time_override": "system-clock-only",
+            # tinfoil-python's verify_tdx_quote only does §4.1.2 steps 1-4
+            # (structural). The full §4.7 collateral evaluation
+            # (verify_tcb_info_signature + verify_qe_identity_signature +
+            # TCB level matching) needs a wrapper in cmd_verify_attestation_
+            # tdx — not yet wired. Phase 2B fixtures skip cleanly until then.
+            "tcb_evaluation_supported": False,
         },
         "platforms_supported": ["sev-snp", "tdx"],
         "transport_modes_supported": ["tls-pinning"],

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -102,6 +102,7 @@ def _capabilities() -> dict[str, Any]:
             "verify-hardware-measurements",
             "verify-attestation-tdx",
             "verify-attestation-sev",
+            "verify-full",
         ],
         "sigstore": {
             "trust_root_loading": "configurable",
@@ -215,7 +216,7 @@ def _capabilities() -> dict[str, Any]:
         },
         "platforms_supported": ["sev-snp", "tdx"],
         "transport_modes_supported": ["tls-pinning"],
-        "flow_modes_supported": ["standard"],
+        "flow_modes_supported": ["standard", "pinned"],
         "known_quirks": {
             "sigstore.workflow_ref_check_via_startswith":
                 "We replaced sigstore.verify.policy's regex-based GitHubWorkflowRefPattern with a strict-prefix startswith() check (SPEC §5.3 reads as prefix, not regex).",
@@ -377,60 +378,29 @@ def _classify(message: str) -> Tuple[str, str]:
     return ("BUNDLE_MALFORMED", "5.2")
 
 
-def cmd_verify_sigstore() -> int:
-    """Read stdin JSON, run verify_sigstore_bundle_with_policy, emit output."""
-    try:
-        raw = sys.stdin.read()
-    except Exception as e:
-        sys.stderr.write(f"error reading stdin: {e}\n")
-        return EXIT_INTERNAL
+def _run_verify_sigstore_inner(inp: dict[str, Any]) -> "SigstoreVerification | tuple[str, str, str]":
+    """Inner sigstore verification logic — shared by cmd_verify_sigstore and
+    cmd_verify_full. Returns the SigstoreVerification on success, or a
+    (code, spec_ref, message) rejection triple on failure.
 
-    try:
-        inp = json.loads(raw)
-    except json.JSONDecodeError as e:
-        return _emit_rejection(
-            "BUNDLE_MALFORMED",
-            "5.2",
-            f"input is not valid JSON: {e}",
-            EXIT_BAD_INPUT,
-        )
-
-    if inp.get("schema_version") != "1":
-        return _emit_rejection(
-            "BUNDLE_MALFORMED",
-            "5.2",
-            'input.schema_version != "1"',
-            EXIT_BAD_INPUT,
-        )
-
+    The verify-full envelope's nested sigstore block omits schema_version
+    (the envelope carries it), so this helper accepts missing schema_version
+    as "1"."""
+    sv = inp.get("schema_version", "1")
+    if sv != "1":
+        return ("BUNDLE_MALFORMED", "5.2", 'input.schema_version != "1"')
     try:
         bundle_bytes = base64.b64decode(inp["bundle_b64"])
     except Exception as e:
-        return _emit_rejection(
-            "BUNDLE_MALFORMED",
-            "5.2",
-            f"bundle_b64 not valid base64: {e}",
-            EXIT_BAD_INPUT,
-        )
-
+        return ("BUNDLE_MALFORMED", "5.2", f"bundle_b64 not valid base64: {e}")
     try:
         trust_root_bytes = base64.b64decode(inp["trust_root_b64"])
     except Exception as e:
-        return _emit_rejection(
-            "TRUST_ROOT_INVALID",
-            "5.1",
-            f"trust_root_b64 not valid base64: {e}",
-            EXIT_BAD_INPUT,
-        )
+        return ("TRUST_ROOT_INVALID", "5.1", f"trust_root_b64 not valid base64: {e}")
     try:
         trust_root_json = trust_root_bytes.decode("utf-8")
     except UnicodeDecodeError as e:
-        return _emit_rejection(
-            "TRUST_ROOT_INVALID",
-            "5.1",
-            f"trust_root is not valid UTF-8: {e}",
-            EXIT_REJECT,
-        )
+        return ("TRUST_ROOT_INVALID", "5.1", f"trust_root is not valid UTF-8: {e}")
 
     policy_in = inp.get("policy") or {}
     defaults = default_sigstore_policy(inp.get("repo", ""))
@@ -454,16 +424,13 @@ def cmd_verify_sigstore() -> int:
     )
 
     try:
-        v = verify_sigstore_bundle_with_policy(
+        return verify_sigstore_bundle_with_policy(
             bundle_bytes=bundle_bytes,
             expected_digest_sha256_hex=inp["expected_digest_sha256_hex"],
             policy=policy,
             trust_root_json=trust_root_json,
         )
     except Exception as e:
-        # Walk the exception chain; sigstore's VerificationError may be
-        # wrapped by our ValueError. Concatenate messages so the classifier
-        # sees the most specific text.
         parts = []
         cur: BaseException | None = e
         while cur is not None and len(parts) < 8:
@@ -471,9 +438,42 @@ def cmd_verify_sigstore() -> int:
             cur = cur.__cause__
         message = " | ".join(parts)
         code, spec_ref = _classify(message)
-        return _emit_rejection(code, spec_ref, message, EXIT_REJECT)
+        return (code, spec_ref, message)
 
-    return _emit_accept(v)
+
+def cmd_verify_sigstore() -> int:
+    """Read stdin JSON, run verify_sigstore_bundle_with_policy, emit output."""
+    try:
+        raw = sys.stdin.read()
+    except Exception as e:
+        sys.stderr.write(f"error reading stdin: {e}\n")
+        return EXIT_INTERNAL
+
+    try:
+        inp = json.loads(raw)
+    except json.JSONDecodeError as e:
+        return _emit_rejection(
+            "BUNDLE_MALFORMED",
+            "5.2",
+            f"input is not valid JSON: {e}",
+            EXIT_BAD_INPUT,
+        )
+
+    # cmd_verify_sigstore requires schema_version explicitly (the verify-full
+    # envelope's sigstore sub-block defaults it instead — see inner helper).
+    if inp.get("schema_version") != "1":
+        return _emit_rejection(
+            "BUNDLE_MALFORMED",
+            "5.2",
+            'input.schema_version != "1"',
+            EXIT_BAD_INPUT,
+        )
+
+    result = _run_verify_sigstore_inner(inp)
+    if isinstance(result, tuple):
+        code, spec_ref, message = result
+        return _emit_rejection(code, spec_ref, message, EXIT_REJECT)
+    return _emit_accept(result)
 
 
 def _print_help() -> None:
@@ -1415,25 +1415,29 @@ def _maybe_override_sev_time(_timestamp: int | None):
     yield
 
 
-def cmd_verify_attestation_sev() -> int:
-    try:
-        raw = sys.stdin.read()
-        data = json.loads(raw)
-    except json.JSONDecodeError as e:
-        sys.stderr.write(f"input schema violation: {e}\n")
-        return EXIT_BAD_INPUT
+def _run_verify_attestation_sev_inner(
+    data: dict[str, Any],
+) -> "tuple[Measurement, bytes, dict[str, Any]] | tuple[str, str, str]":
+    """Inner SEV verification logic — shared by cmd_verify_attestation_sev
+    and cmd_verify_full. On success returns (measurement, report_bytes,
+    body_fields_dict); on failure returns a (code, spec_ref, message) triple.
 
-    if data.get("schema_version") != "1":
-        sys.stderr.write('schema_version must be "1"\n')
-        return EXIT_BAD_INPUT
+    Distinguish by tuple length: success is 3-tuple of (Measurement, bytes,
+    dict); failure is 3-tuple of (str, str, str). Callers should isinstance
+    on the first element.
+
+    schema_version defaults to "1" when absent so the verify-full envelope's
+    nested attestation_sev block (which omits it) works.
+    """
+    sv = data.get("schema_version", "1")
+    if sv != "1":
+        return ("REPORT_FORMAT_UNSUPPORTED", "3.1", 'schema_version != "1"')
 
     att_doc_b64 = data.get("attestation_doc_b64")
     vcek_b64 = data.get("vcek_der_b64")
     if not att_doc_b64 or not vcek_b64:
-        return _emit_sev_rejection(
-            "REPORT_FORMAT_UNSUPPORTED", "3.1",
-            "attestation_doc_b64 and vcek_der_b64 are required",
-        )
+        return ("REPORT_FORMAT_UNSUPPORTED", "3.1",
+                "attestation_doc_b64 and vcek_der_b64 are required")
 
     # Decompress + length-check locally so REPORT_TRUNCATED surfaces before
     # the lib's Report() constructor (which raises a generic parse error).
@@ -1441,30 +1445,22 @@ def cmd_verify_attestation_sev() -> int:
     try:
         gz_bytes = base64.standard_b64decode(att_doc_b64)
     except Exception as e:
-        return _emit_sev_rejection(
-            "REPORT_FORMAT_UNSUPPORTED", "3.1",
-            f"attestation_doc_b64 not valid base64: {e}",
-        )
+        return ("REPORT_FORMAT_UNSUPPORTED", "3.1",
+                f"attestation_doc_b64 not valid base64: {e}")
     try:
         report_bytes = _gzip.decompress(gz_bytes)
     except Exception as e:
-        return _emit_sev_rejection(
-            "REPORT_FORMAT_UNSUPPORTED", "3.1",
-            f"gzip decompress failed: {e}",
-        )
+        return ("REPORT_FORMAT_UNSUPPORTED", "3.1",
+                f"gzip decompress failed: {e}")
     if len(report_bytes) < _SEV_REPORT_LEN:
-        return _emit_sev_rejection(
-            "REPORT_TRUNCATED", "3.1",
-            f"SEV report is {len(report_bytes)} bytes, expected ≥{_SEV_REPORT_LEN}",
-        )
+        return ("REPORT_TRUNCATED", "3.1",
+                f"SEV report is {len(report_bytes)} bytes, expected ≥{_SEV_REPORT_LEN}")
 
     try:
         vcek_der = base64.standard_b64decode(vcek_b64)
     except Exception as e:
-        return _emit_sev_rejection(
-            "VCEK_CHAIN_INVALID", "3.3.3",
-            f"vcek_der_b64 not valid base64: {e}",
-        )
+        return ("VCEK_CHAIN_INVALID", "3.3.3",
+                f"vcek_der_b64 not valid base64: {e}")
 
     # Build the chain directly with the supplied VCEK + embedded ARK/ASK.
     # Bypasses CertificateChain.from_report which would fetch VCEK from KDS.
@@ -1481,7 +1477,7 @@ def cmd_verify_attestation_sev() -> int:
         report = _Report(report_bytes)
     except Exception as e:
         code, ref = _classify_sev_error(f"failed to parse report: {e}")
-        return _emit_sev_rejection(code, ref, str(e))
+        return (code, ref, str(e))
 
     # Phase 4B-SEV: if the fixture supplies synthetic ARK/ASK PEMs, parse
     # those instead of the lib's embedded production constants. Mirrors
@@ -1494,10 +1490,8 @@ def cmd_verify_attestation_sev() -> int:
         ark = x509.load_pem_x509_certificate(ark_pem_bytes)
         ask = x509.load_pem_x509_certificate(ask_pem_bytes)
     except Exception as e:
-        return _emit_sev_rejection(
-            "ARK_UNTRUSTED", "3.3.1",
-            f"failed to parse AMD chain (fixture-supplied={bool(fixture_ark_pem)}): {e}",
-        )
+        return ("ARK_UNTRUSTED", "3.3.1",
+                f"failed to parse AMD chain (fixture-supplied={bool(fixture_ark_pem)}): {e}")
     try:
         with _warnings.catch_warnings():
             _warnings.filterwarnings(
@@ -1507,10 +1501,8 @@ def cmd_verify_attestation_sev() -> int:
             )
             vcek = x509.load_der_x509_certificate(vcek_der)
     except Exception as e:
-        return _emit_sev_rejection(
-            "VCEK_CHAIN_INVALID", "3.3.5",
-            f"could not interpret VCEK DER: {e}",
-        )
+        return ("VCEK_CHAIN_INVALID", "3.3.5",
+                f"could not interpret VCEK DER: {e}")
 
     chain = CertificateChain(ark=ark, ask=ask, vcek=vcek)
 
@@ -1531,22 +1523,17 @@ def cmd_verify_attestation_sev() -> int:
         sys.stdout = orig_stdout
         sys.stderr.write(captured.getvalue())
         code, ref = _classify_sev_error(str(e))
-        return _emit_sev_rejection(code, ref, str(e))
+        return (code, ref, str(e))
     sys.stdout = orig_stdout
     lib_diag = captured.getvalue()
     if lib_diag:
         sys.stderr.write(lib_diag)
     if not ok:
-        # Differentiate signature vs chain failure based on captured lib
-        # output — verify_chain prints "Certificate chain verification
-        # failed" / "VCEK certificate validation failed" etc., while the
-        # report signature path prints "Attestation signature verification
-        # failed". Fall back to a generic REPORT_SIGNATURE_INVALID.
         diag_msg = lib_diag or "verification returned False"
         code, ref = _classify_sev_error(diag_msg)
         if code == "QV_RESULT_TERMINAL_UNSPECIFIED":
             code, ref = "REPORT_SIGNATURE_INVALID", "3.6"
-        return _emit_sev_rejection(code, ref, diag_msg.strip() or "verification returned False")
+        return (code, ref, diag_msg.strip() or "verification returned False")
 
     # Skip the lib's validate_report — its hardcoded production policy
     # (MigrateMA=False, debug=False, smt=True, etc.) is mostly satisfied by
@@ -1559,13 +1546,41 @@ def cmd_verify_attestation_sev() -> int:
     # VCEK_TCB_MISMATCH surface cleanly.
     vcek_viol = _enforce_sev_vcek_cross_checks(report_bytes, vcek)
     if vcek_viol:
-        return _emit_sev_rejection(*vcek_viol)
+        return vcek_viol
 
     pol_viol = _enforce_sev_policy(report_bytes, data.get("policy"))
     if pol_viol:
-        return _emit_sev_rejection(*pol_viol)
+        return pol_viol
 
     body_fields = _decode_sev_body_fields(report_bytes)
+    measurement = Measurement(
+        type=PredicateType.SEV_GUEST_V2,
+        registers=[body_fields["measurement_hex"]],
+    )
+    return (measurement, report_bytes, body_fields)
+
+
+def cmd_verify_attestation_sev() -> int:
+    try:
+        raw = sys.stdin.read()
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"input schema violation: {e}\n")
+        return EXIT_BAD_INPUT
+
+    # cmd_verify_attestation_sev requires schema_version explicitly (the
+    # verify-full envelope's attestation_sev sub-block omits it; the inner
+    # helper defaults to "1").
+    if data.get("schema_version") != "1":
+        sys.stderr.write('schema_version must be "1"\n')
+        return EXIT_BAD_INPUT
+
+    result = _run_verify_attestation_sev_inner(data)
+    # Disambiguate success (Measurement, bytes, dict) vs rejection (str, str, str).
+    if isinstance(result[0], str):
+        code, spec_ref, message = result  # type: ignore[misc]
+        return _emit_sev_rejection(code, spec_ref, message)
+    _measurement, _report_bytes, body_fields = result
     out_body = {
         "stage": "verify-attestation-sev",
         "accepted": True,
@@ -1580,6 +1595,168 @@ def cmd_verify_attestation_sev() -> int:
     json.dump(out_body, sys.stdout, indent=2, sort_keys=True)
     sys.stdout.write("\n")
     return EXIT_ACCEPT
+
+
+# =============================================================================
+# verify-full (SPEC §11)
+# =============================================================================
+
+def _emit_full_rejection(code: str, stage: str, spec_ref: str, message: str) -> int:
+    body = {
+        "stage": "verify-full",
+        "accepted": False,
+        "rejection": {
+            "code": code,
+            "stage": stage,
+            "spec_ref": spec_ref,
+            "message": message,
+        },
+    }
+    json.dump(body, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return EXIT_REJECT
+
+
+def _classify_measurement_compare_error(e: Exception) -> tuple[str, str]:
+    """Map measurement-comparison exceptions to SPEC-anchored rejection codes."""
+    if isinstance(e, Rtmr3NotZeroError):
+        return "MEASUREMENT_RTMR3_NONZERO", "7.3.2"
+    if isinstance(e, FormatMismatchError):
+        return "MEASUREMENT_TYPE_COMBINATION_UNSUPPORTED", "7.3.5"
+    if isinstance(e, MeasurementMismatchError):
+        return "MEASUREMENT_MISMATCH", "7.3"
+    return "MEASUREMENT_MISMATCH", "7.3"
+
+
+def cmd_verify_full() -> int:
+    try:
+        raw = sys.stdin.read()
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        return _emit_full_rejection(
+            "BUNDLE_MALFORMED", "verify-full", "11",
+            f"input is not valid JSON: {e}",
+        )
+
+    if data.get("schema_version") != "1":
+        return _emit_full_rejection(
+            "BUNDLE_MALFORMED", "verify-full", "11",
+            'input.schema_version != "1"',
+        )
+
+    mode = data.get("mode", "")
+    if mode in ("standard", "bundle"):
+        sig_in = data.get("sigstore")
+        if not isinstance(sig_in, dict):
+            return _emit_full_rejection(
+                "BUNDLE_MALFORMED", "verify-full", "11.1",
+                'mode="standard"/"bundle" requires "sigstore" input block',
+            )
+        sig_result = _run_verify_sigstore_inner(sig_in)
+        if isinstance(sig_result, tuple):
+            code, spec_ref, msg = sig_result
+            return _emit_full_rejection(code, "verify-sigstore", spec_ref, msg)
+        sig_measurement = sig_result.measurement
+
+        sev_in = data.get("attestation_sev")
+        if not isinstance(sev_in, dict):
+            return _emit_full_rejection(
+                "BUNDLE_MALFORMED", "verify-full", "11.1",
+                'mode="standard"/"bundle" requires attestation_sev '
+                "(TDX path not wired yet on Python)",
+            )
+        sev_result = _run_verify_attestation_sev_inner(sev_in)
+        if isinstance(sev_result[0], str):
+            code, spec_ref, msg = sev_result  # type: ignore[misc]
+            return _emit_full_rejection(code, "verify-attestation-sev", spec_ref, msg)
+        att_measurement, _report, _body = sev_result
+
+        try:
+            sig_measurement.assert_equal(att_measurement)
+        except Exception as e:
+            code, spec_ref = _classify_measurement_compare_error(e)
+            return _emit_full_rejection(code, "verify-measurement", spec_ref, str(e))
+
+        fp = att_measurement.fingerprint()
+        out_body = {
+            "stage": "verify-full",
+            "accepted": True,
+            "outputs": {
+                "mode": mode,
+                "platform": "sev-snp",
+                "sigstore_measurement": {
+                    "type": sig_measurement.type.value
+                    if hasattr(sig_measurement.type, "value")
+                    else str(sig_measurement.type),
+                    "registers": sig_measurement.registers,
+                },
+                "attestation_measurement": {
+                    "type": att_measurement.type.value
+                    if hasattr(att_measurement.type, "value")
+                    else str(att_measurement.type),
+                    "registers": att_measurement.registers,
+                },
+                "final_measurement_fingerprint_hex": fp,
+            },
+        }
+        json.dump(out_body, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return EXIT_ACCEPT
+
+    if mode == "pinned":
+        pin_in = data.get("pinned_measurement")
+        if not isinstance(pin_in, dict):
+            return _emit_full_rejection(
+                "BUNDLE_MALFORMED", "verify-full", "11.3",
+                'mode="pinned" requires "pinned_measurement"',
+            )
+        pin_measurement, code, spec_ref = _normalize_measurement(pin_in)
+        if pin_measurement is None:
+            return _emit_full_rejection(code, "verify-full", spec_ref,
+                                        "pinned_measurement invalid")
+
+        sev_in = data.get("attestation_sev")
+        if not isinstance(sev_in, dict):
+            return _emit_full_rejection(
+                "BUNDLE_MALFORMED", "verify-full", "11.3",
+                'mode="pinned" requires attestation_sev',
+            )
+        sev_result = _run_verify_attestation_sev_inner(sev_in)
+        if isinstance(sev_result[0], str):
+            code, spec_ref, msg = sev_result  # type: ignore[misc]
+            return _emit_full_rejection(code, "verify-attestation-sev", spec_ref, msg)
+        att_measurement, _report, _body = sev_result
+
+        try:
+            pin_measurement.assert_equal(att_measurement)
+        except Exception as e:
+            code, spec_ref = _classify_measurement_compare_error(e)
+            return _emit_full_rejection(code, "verify-measurement", spec_ref, str(e))
+
+        fp = att_measurement.fingerprint()
+        out_body = {
+            "stage": "verify-full",
+            "accepted": True,
+            "outputs": {
+                "mode": "pinned",
+                "platform": "sev-snp",
+                "attestation_measurement": {
+                    "type": att_measurement.type.value
+                    if hasattr(att_measurement.type, "value")
+                    else str(att_measurement.type),
+                    "registers": att_measurement.registers,
+                },
+                "final_measurement_fingerprint_hex": fp,
+            },
+        }
+        json.dump(out_body, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return EXIT_ACCEPT
+
+    return _emit_full_rejection(
+        "BUNDLE_MALFORMED", "verify-full", "11",
+        f"unknown mode {mode!r} (allowed: standard, bundle, pinned)",
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1600,6 +1777,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_verify_attestation_tdx()
     if sub == "verify-attestation-sev":
         return cmd_verify_attestation_sev()
+    if sub == "verify-full":
+        return cmd_verify_full()
     if sub in ("", "help", "-h", "--help"):
         _print_help()
         return EXIT_ACCEPT

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -157,9 +157,9 @@ def _capabilities() -> dict[str, Any]:
             "rejects_duplicate_sct_log": True,
             # sigstore-python's verify_dsse checks subject[0] only.
             "checks_only_subject_0": True,
-            # sigstore-python's in-toto parser tolerates extra top-level
-            # fields (pydantic's extra=allow on the statement model).
-            "in_toto_statement_tolerates_extra_fields": True,
+            # reject_unknown_intoto_fields rejects statements with unknown
+            # top-level fields (SPEC §5.4), matching go.
+            "in_toto_statement_tolerates_extra_fields": False,
         },
         "measurement": {
             "compare_multiplatform_to_tdx_supported": True,
@@ -338,6 +338,11 @@ def _classify(message: str) -> Tuple[str, str]:
     # reject_legacy_bundle_format.
     if "legacy bundle format" in low:
         return ("BUNDLE_MALFORMED", "5.2")
+
+    # in-toto statement with unknown top-level fields, rejected by
+    # reject_unknown_intoto_fields (SPEC §5.4).
+    if "unknown top-level field" in low:
+        return ("BUNDLE_MALFORMED", "5.4")
 
     # sigstore-python's `OIDCIssuer` (V1) and `OIDCIssuerV2` policies raise
     # stable English message forms. Catch them before generic patterns. Note

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -21,8 +21,11 @@ import json
 import sys
 from typing import Any, Tuple
 
+from ..attestation import verify_tdx_hardware
 from ..attestation.types import (
     FormatMismatchError,
+    HardwareMeasurement,
+    HardwareMeasurementError,
     Measurement,
     MeasurementMismatchError,
     PredicateType,
@@ -64,7 +67,11 @@ def _capabilities() -> dict[str, Any]:
         "schema_version": "1",
         "sdk": SDK_NAME,
         "sdk_version": _sdk_version(),
-        "stages_supported": ["verify-sigstore", "verify-measurement"],
+        "stages_supported": [
+            "verify-sigstore",
+            "verify-measurement",
+            "verify-hardware-measurements",
+        ],
         "sigstore": {
             "trust_root_loading": "configurable",
             # `sigstore` 4.2 verifies cert chain validity against the
@@ -498,6 +505,75 @@ def cmd_verify_measurement() -> int:
     return EXIT_ACCEPT
 
 
+# -----------------------------------------------------------------------------
+# verify-hardware-measurements (SPEC §6)
+# -----------------------------------------------------------------------------
+
+TDX_URI = "https://tinfoil.sh/predicate/tdx-guest/v2"
+
+
+def _emit_hardware_rejection(code: str, spec_ref: str, message: str) -> int:
+    body = {
+        "stage": "verify-hardware-measurements",
+        "accepted": False,
+        "rejection": {"code": code, "spec_ref": spec_ref, "message": message},
+    }
+    json.dump(body, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return EXIT_REJECT
+
+
+def cmd_verify_hardware_measurements() -> int:
+    raw = sys.stdin.read()
+    try:
+        inp = json.loads(raw)
+    except Exception as e:
+        sys.stderr.write(f"input schema violation: {e}\n")
+        return EXIT_BAD_INPUT
+    if inp.get("schema_version") != "1":
+        sys.stderr.write('schema_version must be "1"\n')
+        return EXIT_BAD_INPUT
+
+    enc = inp.get("enclave_measurement") or {}
+    if enc.get("type") != TDX_URI:
+        return _emit_hardware_rejection(
+            "ENCLAVE_MEASUREMENT_TYPE_INVALID", "6.3",
+            "enclave measurement type is not TdxGuestV2",
+        )
+    regs = enc.get("registers", [])
+    if not isinstance(regs, list) or len(regs) != TDX_REGISTER_COUNT:
+        return _emit_hardware_rejection(
+            "ENCLAVE_REGISTER_COUNT_INVALID", "6.3",
+            f"TDX enclave measurement must have {TDX_REGISTER_COUNT} registers, got {len(regs)}",
+        )
+
+    # SPEC §7.3 lowercase normalization.
+    enclave_lower = [r.lower() for r in regs]
+    enclave = Measurement(type=PredicateType.TDX_GUEST_V2, registers=enclave_lower)
+    hw_list = [
+        HardwareMeasurement(id=h["id"], mrtd=h["mrtd"].lower(), rtmr0=h["rtmr0"].lower())
+        for h in inp.get("hardware_measurements", [])
+    ]
+
+    try:
+        match = verify_tdx_hardware(hw_list, enclave)
+    except HardwareMeasurementError as e:
+        return _emit_hardware_rejection("HARDWARE_NO_MATCH", "6.3", str(e))
+
+    body = {
+        "stage": "verify-hardware-measurements",
+        "accepted": True,
+        "outputs": {
+            "matched_id": match.id,
+            "matched_mrtd": match.mrtd,
+            "matched_rtmr0": match.rtmr0,
+        },
+    }
+    json.dump(body, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return EXIT_ACCEPT
+
+
 def main(argv: list[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
@@ -510,6 +586,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_verify_sigstore()
     if sub == "verify-measurement":
         return cmd_verify_measurement()
+    if sub == "verify-hardware-measurements":
+        return cmd_verify_hardware_measurements()
     if sub in ("", "help", "-h", "--help"):
         _print_help()
         return EXIT_ACCEPT

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -25,8 +25,32 @@ from ..attestation import verify_tdx_hardware
 from ..attestation.abi_tdx import parse_quote as parse_tdx_quote
 from ..attestation.verify_tdx import (
     TdxVerificationError,
+    extract_pck_cert_chain,
     verify_tdx_quote as verify_tdx_quote_crypto,
 )
+from ..attestation import collateral_tdx as _coll
+from ..attestation.collateral_tdx import (
+    CollateralError,
+    PckCrl,
+    RootCrl,
+    TdxCollateral,
+    check_collateral_freshness,
+    parse_qe_identity_response,
+    parse_tcb_info_response,
+    validate_certificate_revocation,
+    validate_qe_identity,
+    validate_tcb_status,
+    validate_tdx_module_identity,
+    verify_qe_identity_signature,
+    verify_tcb_info_signature,
+)
+from ..attestation.cert_utils import parse_pem_chain
+from ..attestation.pck_extensions import extract_pck_extensions
+from ..attestation import intel_root_ca as _intel_root_mod
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from datetime import datetime, timezone
+import contextlib
 from ..attestation.types import (
     FormatMismatchError,
     HardwareMeasurement,
@@ -145,18 +169,25 @@ def _capabilities() -> dict[str, Any]:
             # time. Fixtures that pin expiration_check_date outside the real-
             # now window (e.g. 324-pck-leaf-expired) skip honestly.
             "verification_time_override": "system-clock-only",
-            # tinfoil-python's verify_tdx_quote only does §4.1.2 steps 1-4
-            # (structural). The full §4.7 collateral evaluation
-            # (verify_tcb_info_signature + verify_qe_identity_signature +
-            # TCB level matching) needs a wrapper in cmd_verify_attestation_
-            # tdx — not yet wired. Phase 2B fixtures skip cleanly until then.
-            "tcb_evaluation_supported": False,
+            # Phase 2B/3 wired: cmd_verify_attestation_tdx now orchestrates
+            # the lib's pure validation functions (verify_tcb_info_signature
+            # + verify_qe_identity_signature + check_collateral_freshness +
+            # validate_certificate_revocation + validate_tcb_status +
+            # validate_tdx_module_identity + validate_qe_identity) using
+            # the fixture-injected collateral bytes — no Intel PCS fetch.
+            "tcb_evaluation_supported": True,
             # Phase 4: cmd_verify_attestation_tdx applies SPEC §4.8 /
             # Intel §2.3.2 checks against every policy.expected_*_hex pin
             # the fixture sets — the unmutated quote's body fields are
             # parsed and compared without needing any sigstore-python or
             # lib API surface (pure post-parse Python).
             "extended_td_checks_supported": True,
+            # validate_tcb_status rejects only the terminal statuses
+            # (OutOfDate, OutOfDateConfigurationNeeded, Revoked); the
+            # three non-terminal statuses (SWHardeningNeeded, Config-
+            # urationNeeded, ConfigurationAndSWHardeningNeeded) pass
+            # through per SPEC §4.7.7 default.
+            "accepts_non_terminal_tcb_statuses": True,
         },
         "platforms_supported": ["sev-snp", "tdx"],
         "transport_modes_supported": ["tls-pinning"],
@@ -687,6 +718,184 @@ def _decode_td_attributes(td_attrs: bytes) -> dict[str, bool]:
     }
 
 
+@contextlib.contextmanager
+def _maybe_override_time(timestamp: int | None):
+    """Temporarily replace datetime.now() inside collateral_tdx and
+    cert_utils so all internal freshness/validity checks use the fixture's
+    expiration_check_date instead of real system time. The lib has no
+    public time-injection API; this monkey-patch is the cleanest
+    workaround until verify_intel_chain / check_collateral_freshness /
+    validate_certificate_revocation gain a `now` parameter."""
+    if timestamp is None:
+        yield
+        return
+    import datetime as _dt_module
+    fixed_now = _dt_module.datetime.fromtimestamp(int(timestamp), tz=_dt_module.timezone.utc)
+
+    class _FixedDatetime(_dt_module.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now if tz is None else fixed_now.astimezone(tz)
+
+    from ..attestation import collateral_tdx as _coll_mod
+    from ..attestation import cert_utils as _cert_mod
+    orig_coll_dt = _coll_mod.datetime
+    orig_cert_dt = _cert_mod.datetime
+    _coll_mod.datetime = _FixedDatetime
+    _cert_mod.datetime = _FixedDatetime
+    try:
+        yield
+    finally:
+        _coll_mod.datetime = orig_coll_dt
+        _cert_mod.datetime = orig_cert_dt
+
+
+@contextlib.contextmanager
+def _maybe_override_intel_root(pem: str | None):
+    """Temporarily replace the embedded Intel SGX Root CA with a synthetic
+    one for the duration of the `with` block. Phase 3 synthetic-chain
+    fixtures rely on this so their self-issued root is accepted by
+    cert_utils.verify_intel_chain (which reads the module-level
+    INTEL_SGX_ROOT_CA_PEM via get_intel_root_ca)."""
+    if not pem:
+        yield
+        return
+    orig_pem = _intel_root_mod.INTEL_SGX_ROOT_CA_PEM
+    _intel_root_mod.INTEL_SGX_ROOT_CA_PEM = pem.encode()
+    try:
+        yield
+    finally:
+        _intel_root_mod.INTEL_SGX_ROOT_CA_PEM = orig_pem
+
+
+def _evaluate_collateral(
+    quote, pck_chain, collateral_in: dict, expiration_check_date_unix
+) -> tuple[str, str, str]:
+    """Run Intel §4.7 collateral evaluation against fixture-injected bytes.
+
+    Orchestrates the lib's pure validation functions in the order specified
+    by SPEC §4.9 step 10. Returns (rejection_code, spec_ref, message); empty
+    string code means everything passed."""
+    try:
+        # Step 1: PCK extensions
+        pck_extensions = extract_pck_extensions(pck_chain.pck_cert)
+
+        # Step 2: Parse injected collateral
+        tcb_info_raw = (collateral_in.get("tcb_info_json") or "").encode()
+        qe_identity_raw = (collateral_in.get("qe_identity_json") or "").encode()
+        tcb_info = parse_tcb_info_response(tcb_info_raw)
+        qe_identity = parse_qe_identity_response(qe_identity_raw)
+
+        tcb_issuer_chain_pem = (collateral_in.get("tcb_info_issuer_chain_pem") or "").encode()
+        qe_issuer_chain_pem = (collateral_in.get("qe_identity_issuer_chain_pem") or "").encode()
+        tcb_issuer_chain = parse_pem_chain(tcb_issuer_chain_pem) if tcb_issuer_chain_pem else []
+        qe_issuer_chain = parse_pem_chain(qe_issuer_chain_pem) if qe_issuer_chain_pem else []
+
+        # Step 3: Verify collateral signatures
+        if tcb_issuer_chain:
+            verify_tcb_info_signature(tcb_info_raw, tcb_info, tcb_issuer_chain)
+        if qe_issuer_chain:
+            verify_qe_identity_signature(qe_identity_raw, qe_identity, qe_issuer_chain)
+
+        # Step 4: CRLs
+        pck_crl_der = base64.b64decode(collateral_in.get("pck_crl_der_b64") or "")
+        root_crl_der = base64.b64decode(collateral_in.get("root_crl_der_b64") or "")
+        pck_crl_obj = None
+        root_crl_obj = None
+        if pck_crl_der:
+            crl = x509.load_der_x509_crl(pck_crl_der)
+            pck_crl_obj = PckCrl(crl=crl, ca_type="platform",
+                                 next_update=crl.next_update_utc or datetime.now(timezone.utc))
+        if root_crl_der:
+            crl = x509.load_der_x509_crl(root_crl_der)
+            root_crl_obj = RootCrl(crl=crl,
+                                   next_update=crl.next_update_utc or datetime.now(timezone.utc))
+
+        collateral = TdxCollateral(
+            tcb_info=tcb_info, qe_identity=qe_identity,
+            tcb_info_raw=tcb_info_raw, qe_identity_raw=qe_identity_raw,
+            pck_crl=pck_crl_obj, root_crl=root_crl_obj,
+            tcb_info_issuer_chain=tcb_issuer_chain or None,
+            qe_identity_issuer_chain=qe_issuer_chain or None,
+        )
+
+        # Step 5: Freshness — inline so we can use the fixture-provided
+        # expiration_check_date_unix instead of datetime.now(). The lib's
+        # check_collateral_freshness reads system time directly which
+        # would fire on any older testdata.
+        if expiration_check_date_unix is not None:
+            now_t = datetime.fromtimestamp(int(expiration_check_date_unix), tz=timezone.utc)
+        else:
+            now_t = datetime.now(timezone.utc)
+        if now_t > tcb_info.tcb_info.next_update:
+            return "TCB_INFO_EXPIRED", "4.7", (
+                f"TCB Info nextUpdate {tcb_info.tcb_info.next_update} is past "
+                f"verification_time {now_t}"
+            )
+        if now_t > qe_identity.enclave_identity.next_update:
+            return "QE_IDENTITY_EXPIRED", "4.7", (
+                f"QE Identity nextUpdate {qe_identity.enclave_identity.next_update} "
+                f"is past verification_time {now_t}"
+            )
+
+        # Step 6: Cert revocation
+        validate_certificate_revocation(
+            collateral, pck_chain.pck_cert, pck_chain.intermediate_cert,
+        )
+
+        # Step 7: TCB status (matches level + rejects non-acceptable status)
+        validate_tcb_status(
+            tcb_info.tcb_info,
+            quote.td_quote_body.tee_tcb_svn,
+            pck_extensions,
+        )
+
+        # Step 8: TDX module identity
+        validate_tdx_module_identity(
+            tcb_info.tcb_info,
+            quote.td_quote_body.tee_tcb_svn,
+            quote.td_quote_body.mr_signer_seam,
+            quote.td_quote_body.seam_attributes,
+        )
+
+        # Step 9: QE identity
+        qe_report = quote.signed_data.certification_data.qe_report_data
+        if qe_report is None:
+            return "QE_IDENTITY_FIELD_MISMATCH", "4.4", "Quote missing QE report"
+        qe_parsed = qe_report.qe_report_parsed
+        miscselect_bytes = qe_parsed.misc_select.to_bytes(4, byteorder='little')
+        validate_qe_identity(
+            qe_identity.enclave_identity,
+            qe_parsed.isv_svn, qe_parsed.mr_signer,
+            miscselect_bytes, qe_parsed.attributes, qe_parsed.isv_prod_id,
+        )
+
+    except CollateralError as e:
+        msg = str(e)
+        msg_low = msg.lower()
+        if "tcb status" in msg_low or "no matching tcb" in msg_low or "revoked" in msg_low:
+            return "TCB_REVOKED", "4.7.7", msg
+        if "signature" in msg_low and ("tcb info" in msg_low or "tcbinfo" in msg_low):
+            return "TCB_INFO_SIGNATURE_INVALID", "4.7", msg
+        if "signature" in msg_low and ("qe identity" in msg_low or "enclave identity" in msg_low):
+            return "QE_IDENTITY_SIGNATURE_INVALID", "4.7", msg
+        if "expired" in msg_low and ("tcb" in msg_low or "tcbinfo" in msg_low):
+            return "TCB_INFO_EXPIRED", "4.7", msg
+        if "expired" in msg_low and ("qe" in msg_low or "identity" in msg_low):
+            return "QE_IDENTITY_EXPIRED", "4.7", msg
+        if "mrsigner" in msg_low or "mr_signer" in msg_low:
+            return "QE_IDENTITY_MRSIGNER_MISMATCH", "4.7.9", msg
+        if "qe identity" in msg_low or "enclave identity" in msg_low:
+            return "QE_IDENTITY_FIELD_MISMATCH", "4.7.9", msg
+        if "crl" in msg_low or "revocation" in msg_low:
+            return "PCK_REVOKED", "4.7.4", msg
+        return "QV_RESULT_TERMINAL_UNSPECIFIED", "4.7", msg
+    except Exception as e:
+        return "QV_RESULT_TERMINAL_UNSPECIFIED", "4.7", f"unexpected: {e}"
+
+    return "", "", ""
+
+
 def _enforce_extended_policy(
     raw_quote: bytes, policy: dict
 ) -> tuple[str, str]:
@@ -798,26 +1007,34 @@ def cmd_verify_attestation_tdx() -> int:
     # semantics and fixture 300's calibration.
     tcb_eval_required = policy.get("tcb_evaluation_required", True)
 
-    # Phase 1.5: structural verification only. Phase 3 will add the full
-    # collateral path via verify_tcb_info_signature + verify_qe_identity_
-    # signature + the issuer-chain certs.
-    if tcb_eval_required:
-        return _emit_tdx_rejection(
-            "QV_RESULT_TERMINAL_UNSPECIFIED",
-            "4.7",
-            "tcb_evaluation_required=true not yet wired in tinfoil-python; "
-            "Phase 1.5 only handles the structural path. Use "
-            "tcb_evaluation_required=false for now.",
-        )
+    # Structural verification (Intel §4.1.2 steps 1-4) always runs.
+    # When collateral.intel_root_ca_pem is set (Phase 3 synthetic chain
+    # fixtures), temporarily swap the embedded Intel root for the
+    # synthetic one so chain validation accepts the self-issued chain.
+    collateral_in = inp.get("collateral") or {}
+    custom_root_pem = collateral_in.get("intel_root_ca_pem")
+    # Inject the fixture's verification time into the lib's freshness +
+    # cert-validity checks. This effectively makes
+    # verification_time_override="supported" for the collateral path,
+    # which the structural-only path (verify_tdx_quote) still doesn't honor.
+    fixture_date = inp.get("expiration_check_date_unix")
+    with _maybe_override_intel_root(custom_root_pem), _maybe_override_time(fixture_date):
+        try:
+            pck_chain = verify_tdx_quote_crypto(quote, quote_bytes)
+        except TdxVerificationError as e:
+            code, ref = _classify_tdx_error(e)
+            return _emit_tdx_rejection(code, ref, str(e))
+        except Exception as e:
+            code, ref = _classify_tdx_error(e)
+            return _emit_tdx_rejection(code, ref, f"unexpected: {e}")
 
-    try:
-        verify_tdx_quote_crypto(quote, quote_bytes)
-    except TdxVerificationError as e:
-        code, ref = _classify_tdx_error(e)
-        return _emit_tdx_rejection(code, ref, str(e))
-    except Exception as e:
-        code, ref = _classify_tdx_error(e)
-        return _emit_tdx_rejection(code, ref, f"unexpected: {e}")
+        if tcb_eval_required:
+            code, ref, msg = _evaluate_collateral(
+                quote, pck_chain, collateral_in,
+                inp.get("expiration_check_date_unix"),
+            )
+            if code:
+                return _emit_tdx_rejection(code, ref, msg)
 
     # Phase 4: extended-TD policy checks (SPEC §4.8 / Intel §2.3.2).
     code, msg = _enforce_extended_policy(quote_bytes, policy)

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -186,6 +186,11 @@ def _capabilities() -> dict[str, Any]:
             # parsed and compared without needing any sigstore-python or
             # lib API surface (pure post-parse Python).
             "extended_td_checks_supported": True,
+            "enforces_tcb_evaluation_data_number_minimum": True,
+            "policy_fields_supported": {
+                "expected_fmspc_hex": False,
+                "accepted_qv_results": True,
+            },
             # validate_tcb_status rejects only the terminal statuses
             # (OutOfDate, OutOfDateConfigurationNeeded, Revoked); the
             # three non-terminal statuses (SWHardeningNeeded, Config-
@@ -703,6 +708,11 @@ def _classify_tdx_error(err: Exception) -> Tuple[str, str]:
     if "unsupported quote version" in msg or "quote version" in msg or "version" in msg and "supported" in msg:
         return "QUOTE_FORMAT_UNSUPPORTED", "A.3.1"
 
+    # QE-report signature failures mention the PCK certificate because the
+    # PCK leaf is the verification key; classify them before chain errors.
+    if ("qe report" in msg or "qe_report" in msg) and "signature" in msg:
+        return "QE_REPORT_SIGNATURE_INVALID", "4.4"
+
     # PCK chain (BEFORE the generic "signature" check)
     if "pck" in msg and "chain" in msg:
         return "PCK_CHAIN_INVALID", "4.2"
@@ -714,10 +724,13 @@ def _classify_tdx_error(err: Exception) -> Tuple[str, str]:
         return "PCK_CHAIN_INVALID", "4.2"
 
     # AK / quote signature (generic — must come after chain)
+    if (
+        "ak" in msg and ("bind" in msg or "report data" in msg)
+        or "attestation key" in msg and ("bind" in msg or "report data" in msg)
+    ):
+        return "AK_BINDING_INVALID", "4.5"
     if "qe report" in msg or "qe_report" in msg:
         return "QE_REPORT_SIGNATURE_INVALID", "4.4"
-    if "ak" in msg and ("bind" in msg or "report data" in msg):
-        return "AK_BINDING_INVALID", "4.5"
     if "signature" in msg:
         return "QUOTE_SIGNATURE_INVALID", "4.3"
     if "root" in msg and ("trust" in msg or "ca" in msg):
@@ -793,7 +806,8 @@ def _maybe_override_intel_root(pem: str | None):
 
 
 def _evaluate_collateral(
-    quote, pck_chain, collateral_in: dict, expiration_check_date_unix
+    quote, pck_chain, collateral_in: dict, expiration_check_date_unix,
+    policy: dict | None = None,
 ) -> tuple[str, str, str]:
     """Run Intel §4.7 collateral evaluation against fixture-injected bytes.
 
@@ -862,17 +876,59 @@ def _evaluate_collateral(
                 f"is past verification_time {now_t}"
             )
 
+        # SPEC §4.7.11 lets policy require a minimum collateral
+        # tcbEvaluationDataNumber. The underlying lib exposes this in
+        # freshness helpers, but we enforce it inline so injected-collateral
+        # conformance runs stay deterministic.
+        min_eval = (policy or {}).get("min_tcb_evaluation_data_number")
+        if min_eval is not None:
+            min_eval_int = int(min_eval)
+            tcb_eval_num = tcb_info.tcb_info.tcb_evaluation_data_number
+            qe_eval_num = qe_identity.enclave_identity.tcb_evaluation_data_number
+            if tcb_eval_num < min_eval_int:
+                return "TCB_EVAL_DATA_NUMBER_TOO_LOW", "4.7.11", (
+                    f"TCB Info tcbEvaluationDataNumber {tcb_eval_num} "
+                    f"below minimum {min_eval_int}"
+                )
+            if qe_eval_num < min_eval_int:
+                return "TCB_EVAL_DATA_NUMBER_TOO_LOW", "4.7.11", (
+                    f"QE Identity tcbEvaluationDataNumber {qe_eval_num} "
+                    f"below minimum {min_eval_int}"
+                )
+
         # Step 6: Cert revocation
         validate_certificate_revocation(
             collateral, pck_chain.pck_cert, pck_chain.intermediate_cert,
         )
 
         # Step 7: TCB status (matches level + rejects non-acceptable status)
-        validate_tcb_status(
+        matching_tcb_level = validate_tcb_status(
             tcb_info.tcb_info,
             quote.td_quote_body.tee_tcb_svn,
             pck_extensions,
         )
+        accepted_qv_results = (policy or {}).get("accepted_qv_results")
+        if accepted_qv_results:
+            tcb_status_to_qv_result = {
+                "UpToDate": "OK",
+                "SWHardeningNeeded": "SW_HARDENING_NEEDED",
+                "ConfigurationNeeded": "CONFIG_NEEDED",
+                "ConfigurationAndSWHardeningNeeded": "CONFIG_AND_SW_HARDENING_NEEDED",
+                "OutOfDate": "OUT_OF_DATE",
+                "OutOfDateConfigurationNeeded": "OUT_OF_DATE_CONFIG_NEEDED",
+                "Revoked": "REVOKED",
+            }
+            tcb_status = str(getattr(
+                matching_tcb_level.tcb_status,
+                "value",
+                matching_tcb_level.tcb_status,
+            ))
+            qv_result = tcb_status_to_qv_result.get(tcb_status, tcb_status)
+            if qv_result not in set(accepted_qv_results):
+                return "QV_RESULT_NOT_ACCEPTED_BY_POLICY", "4.7.7", (
+                    f"qv_result {qv_result} from TCB status {tcb_status} "
+                    f"not in accepted_qv_results {accepted_qv_results}"
+                )
 
         # Step 8: TDX module identity
         validate_tdx_module_identity(
@@ -897,6 +953,29 @@ def _evaluate_collateral(
     except CollateralError as e:
         msg = str(e)
         msg_low = msg.lower()
+        if "pck crl" in msg_low and "expired" in msg_low:
+            return "PCK_CRL_EXPIRED", "4.7.4", msg
+        if (
+            ("root ca crl" in msg_low or "root crl" in msg_low)
+            and "expired" in msg_low
+        ):
+            return "ROOT_CRL_EXPIRED", "4.7.4", msg
+        if "intermediate ca" in msg_low and "revoked" in msg_low:
+            return "INTERMEDIATE_REVOKED", "4.7.4", msg
+        if "pck certificate" in msg_low and "revoked" in msg_low:
+            return "PCK_REVOKED", "4.7.4", msg
+        if "tcb info issuer chain" in msg_low and (
+            "chain" in msg_low or "certificate" in msg_low or "root" in msg_low
+        ):
+            return "TCB_INFO_CHAIN_INVALID", "4.7.3", msg
+        if "qe identity id" in msg_low and ("td_qe" in msg_low or "must" in msg_low):
+            return "QE_IDENTITY_ID_INVALID", "4.7.9", msg
+        if "qe identity version" in msg_low and "must" in msg_low:
+            return "QE_IDENTITY_VERSION_INVALID", "4.7.9", msg
+        if "mrsigner" in msg_low or "mr_signer" in msg_low:
+            return "QE_IDENTITY_MRSIGNER_MISMATCH", "4.7.9", msg
+        if "miscselect" in msg_low or "attributes" in msg_low or "isv prodid" in msg_low:
+            return "QE_IDENTITY_FIELD_MISMATCH", "4.7.9", msg
         if "tcb status" in msg_low or "no matching tcb" in msg_low or "revoked" in msg_low:
             return "TCB_REVOKED", "4.7.7", msg
         if "signature" in msg_low and ("tcb info" in msg_low or "tcbinfo" in msg_low):
@@ -907,8 +986,6 @@ def _evaluate_collateral(
             return "TCB_INFO_EXPIRED", "4.7", msg
         if "expired" in msg_low and ("qe" in msg_low or "identity" in msg_low):
             return "QE_IDENTITY_EXPIRED", "4.7", msg
-        if "mrsigner" in msg_low or "mr_signer" in msg_low:
-            return "QE_IDENTITY_MRSIGNER_MISMATCH", "4.7.9", msg
         if "qe identity" in msg_low or "enclave identity" in msg_low:
             return "QE_IDENTITY_FIELD_MISMATCH", "4.7.9", msg
         if "crl" in msg_low or "revocation" in msg_low:
@@ -1078,6 +1155,7 @@ def cmd_verify_attestation_tdx() -> int:
             code, ref, msg = _evaluate_collateral(
                 quote, pck_chain, collateral_in,
                 inp.get("expiration_check_date_unix"),
+                policy,
             )
             if code:
                 return _emit_tdx_rejection(code, ref, msg)

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -147,9 +147,10 @@ def _capabilities() -> dict[str, Any]:
             # V2 (.1.8) extension first and falls back to the deprecated V1
             # (.1.1) only when V2 is absent — matching go/rs/js. See SPEC §5.3.
             "oidc_issuer_v2_preferred": True,
-            # sigstore-python collapses missing-SCT and duplicate-SCT into
-            # the same "Expected one certificate timestamp" error.
-            "scts_count_distinguish_missing_vs_duplicate": False,
+            # reject_duplicate_sct_logs runs ahead of sigstore-python's
+            # exactly-one check, so missing SCTs classify as SCT_INSUFFICIENT
+            # while a repeated log id classifies as SCT_DUPLICATE_LOG.
+            "scts_count_distinguish_missing_vs_duplicate": True,
             # sigstore-python rejects duplicate SCTs via the same
             # count-based check (it rejects either case as
             # "Expected one certificate timestamp").

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -140,6 +140,11 @@ def _capabilities() -> dict[str, Any]:
             # lands when Phase 3 fixtures need it.
             "supported": True,
             "injected_collateral_supported": True,
+            # cert_utils.verify_intel_chain calls datetime.now(timezone.utc)
+            # unconditionally — there's no API to inject the verification
+            # time. Fixtures that pin expiration_check_date outside the real-
+            # now window (e.g. 324-pck-leaf-expired) skip honestly.
+            "verification_time_override": "system-clock-only",
         },
         "platforms_supported": ["sev-snp", "tdx"],
         "transport_modes_supported": ["tls-pinning"],
@@ -614,19 +619,43 @@ def _emit_tdx_rejection(code: str, spec_ref: str, message: str) -> int:
 
 def _classify_tdx_error(err: Exception) -> Tuple[str, str]:
     msg = str(err).lower()
-    if "signature" in msg:
-        return "QUOTE_SIGNATURE_INVALID", "4.3"
+    # Order matters: chain errors mention "signature" but should map to
+    # PCK_CHAIN_INVALID, not QUOTE_SIGNATURE_INVALID.
+
+    # Quote header / structural parse failures
+    if "invalid tee type" in msg or "tee type" in msg:
+        return "WRONG_TEE_TYPE", "A.3.1"
+    if "attestation key type" in msg or "unsupported.*key type" in msg:
+        return "ATTESTATION_KEY_TYPE_UNSUPPORTED", "A.3.1"
+    if "qe vendor" in msg or "unknown qe" in msg:
+        return "QE_VENDOR_UNKNOWN", "A.3.1"
+    if "quote too short" in msg or "minimum" in msg and "size" in msg:
+        return "QUOTE_TRUNCATED", "A.3"
+    if "certification data" in msg or "size mismatch" in msg or "data size" in msg:
+        return "QUOTE_FORMAT_UNSUPPORTED", "A.3.9"
+    if "unsupported quote version" in msg or "quote version" in msg or "version" in msg and "supported" in msg:
+        return "QUOTE_FORMAT_UNSUPPORTED", "A.3.1"
+
+    # PCK chain (BEFORE the generic "signature" check)
+    if "pck" in msg and "chain" in msg:
+        return "PCK_CHAIN_INVALID", "4.2"
+    if "certificate chain" in msg or "cert chain" in msg:
+        return "PCK_CHAIN_INVALID", "4.2"
+    if "expired" in msg or "not yet valid" in msg:
+        return "PCK_EXPIRED", "4.2"
+    if ("pck" in msg or "intermediate" in msg or "root" in msg) and "certificate" in msg:
+        return "PCK_CHAIN_INVALID", "4.2"
+
+    # AK / quote signature (generic — must come after chain)
     if "qe report" in msg or "qe_report" in msg:
         return "QE_REPORT_SIGNATURE_INVALID", "4.4"
     if "ak" in msg and ("bind" in msg or "report data" in msg):
         return "AK_BINDING_INVALID", "4.5"
-    if "pck" in msg and "chain" in msg:
-        return "PCK_CHAIN_INVALID", "4.2"
-    if "expired" in msg:
-        return "PCK_EXPIRED", "4.2"
+    if "signature" in msg:
+        return "QUOTE_SIGNATURE_INVALID", "4.3"
     if "root" in msg and ("trust" in msg or "ca" in msg):
         return "ROOT_CA_UNTRUSTED", "4.2"
-    if "format" in msg or "version" in msg:
+    if "format" in msg:
         return "QUOTE_FORMAT_UNSUPPORTED", "A.3"
     return "QV_RESULT_TERMINAL_UNSPECIFIED", "4.1.2"
 

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -151,6 +151,12 @@ def _capabilities() -> dict[str, Any]:
             # TCB level matching) needs a wrapper in cmd_verify_attestation_
             # tdx — not yet wired. Phase 2B fixtures skip cleanly until then.
             "tcb_evaluation_supported": False,
+            # Phase 4: cmd_verify_attestation_tdx applies SPEC §4.8 /
+            # Intel §2.3.2 checks against every policy.expected_*_hex pin
+            # the fixture sets — the unmutated quote's body fields are
+            # parsed and compared without needing any sigstore-python or
+            # lib API surface (pure post-parse Python).
+            "extended_td_checks_supported": True,
         },
         "platforms_supported": ["sev-snp", "tdx"],
         "transport_modes_supported": ["tls-pinning"],
@@ -681,6 +687,87 @@ def _decode_td_attributes(td_attrs: bytes) -> dict[str, bool]:
     }
 
 
+def _enforce_extended_policy(
+    raw_quote: bytes, policy: dict
+) -> tuple[str, str]:
+    """Apply SPEC §4.8 / Intel §2.3.2 checks against quote body fields.
+
+    Each policy.expected_*_hex pin is optional; only enforced when set.
+    Returns ("", "") on success, otherwise (rejection_code, message).
+    """
+    if len(raw_quote) < 48 + 584:
+        return "", ""
+    header = raw_quote[:48]
+    body = raw_quote[48:48 + 584]
+
+    qe_vendor = header[12:28]
+    tee_tcb_svn = body[0:16]
+    mr_seam = body[16:64]
+    mr_signer_seam = body[64:112]
+    seam_attrs = body[112:120]
+    td_attrs = body[120:128]
+    xfam = body[128:136]
+    mr_td = body[136:184]
+    mr_config_id = body[184:232]
+    mr_owner = body[232:280]
+    mr_owner_config = body[280:328]
+    rtmr3 = body[472:520]
+    report_data = body[520:584]
+
+    def match_hex(expected_hex: str | None, got: bytes) -> bool:
+        if not expected_hex:
+            return True
+        try:
+            expected = bytes.fromhex(expected_hex.strip().lower())
+        except ValueError:
+            return False
+        if len(expected) != len(got):
+            return False
+        return got == expected
+
+    pins = [
+        ("expected_td_attributes_hex",      td_attrs,        "TD_ATTRIBUTES_MISMATCH",      "td_attributes"),
+        ("expected_xfam_hex",               xfam,            "XFAM_MISMATCH",               "xfam"),
+        ("expected_mr_signer_seam_hex",     mr_signer_seam,  "MR_SIGNER_SEAM_MISMATCH",     "mr_signer_seam"),
+        ("expected_seam_attributes_hex",    seam_attrs,      "SEAM_ATTRIBUTES_MISMATCH",    "seam_attributes"),
+        ("expected_mrtd_hex",               mr_td,           "MRTD_MISMATCH",               "mrtd"),
+        ("expected_mr_config_id_hex",       mr_config_id,    "MR_CONFIG_ID_MISMATCH",       "mr_config_id"),
+        ("expected_mr_owner_hex",           mr_owner,        "MR_OWNER_MISMATCH",           "mr_owner"),
+        ("expected_mr_owner_config_hex",    mr_owner_config, "MR_OWNER_CONFIG_MISMATCH",    "mr_owner_config"),
+        ("expected_rtmr3_hex",              rtmr3,           "RTMR3_NONZERO",               "rtmr3"),
+        ("expected_report_data_hex",        report_data,     "REPORT_DATA_MISMATCH",        "report_data"),
+        ("expected_qe_vendor_id_hex",       qe_vendor,       "QE_VENDOR_ID_MISMATCH",       "qe_vendor_id"),
+    ]
+    for field_name, got, code, label in pins:
+        expected_hex = policy.get(field_name)
+        if expected_hex is not None and not match_hex(expected_hex, got):
+            return code, f"{label} {got.hex()} != policy expected {expected_hex.strip().lower()}"
+
+    # MR_SEAM allowlist
+    allowlist = policy.get("expected_mrseam_allowlist")
+    if allowlist:
+        got_hex = mr_seam.hex()
+        if not any(got_hex == entry.strip().lower() for entry in allowlist):
+            return ("MR_SEAM_NOT_ALLOWED",
+                    f"mr_seam {got_hex} not in policy allowlist ({len(allowlist)} entries)")
+
+    # Min TEE_TCB_SVN — component-wise comparison (SPEC §4.8.7).
+    min_hex = policy.get("min_tee_tcb_svn_hex")
+    if min_hex:
+        try:
+            minimum = bytes.fromhex(min_hex.strip().lower())
+            if len(minimum) == 16:
+                for i in range(16):
+                    if tee_tcb_svn[i] < minimum[i]:
+                        return ("TEE_TCB_SVN_BELOW_MINIMUM",
+                                f"tee_tcb_svn[{i}]={tee_tcb_svn[i]} < min[{i}]={minimum[i]} "
+                                f"(quote={tee_tcb_svn.hex()}, minimum={minimum.hex()})")
+        except ValueError:
+            pass
+
+    return "", ""
+
+
 def cmd_verify_attestation_tdx() -> int:
     raw = sys.stdin.read()
     try:
@@ -731,6 +818,11 @@ def cmd_verify_attestation_tdx() -> int:
     except Exception as e:
         code, ref = _classify_tdx_error(e)
         return _emit_tdx_rejection(code, ref, f"unexpected: {e}")
+
+    # Phase 4: extended-TD policy checks (SPEC §4.8 / Intel §2.3.2).
+    code, msg = _enforce_extended_policy(quote_bytes, policy)
+    if code:
+        return _emit_tdx_rejection(code, "4.8", msg)
 
     # Build outputs from the parsed body.
     body = quote.td_quote_body

--- a/src/tinfoil/conformance/cli.py
+++ b/src/tinfoil/conformance/cli.py
@@ -91,6 +91,15 @@ def _capabilities() -> dict[str, Any]:
             # sigstore-python collapses missing-SCT and duplicate-SCT into
             # the same "Expected one certificate timestamp" error.
             "scts_count_distinguish_missing_vs_duplicate": False,
+            # sigstore-python rejects duplicate SCTs via the same
+            # count-based check (it rejects either case as
+            # "Expected one certificate timestamp").
+            "rejects_duplicate_sct_log": True,
+            # sigstore-python's verify_dsse checks subject[0] only.
+            "checks_only_subject_0": True,
+            # sigstore-python's in-toto parser tolerates extra top-level
+            # fields (pydantic's extra=allow on the statement model).
+            "in_toto_statement_tolerates_extra_fields": True,
         },
         "platforms_supported": ["sev-snp", "tdx"],
         "transport_modes_supported": ["tls-pinning"],

--- a/src/tinfoil/conformance/sigstore.py
+++ b/src/tinfoil/conformance/sigstore.py
@@ -22,6 +22,7 @@ from ..sigstore import (
     OIDCIssuerV2Preferred,
     reject_duplicate_sct_logs,
     reject_legacy_bundle_format,
+    reject_unknown_intoto_fields,
 )
 
 OIDC_ISSUER = "https://token.actions.githubusercontent.com"
@@ -132,6 +133,7 @@ def verify_sigstore_bundle_with_policy(
         )
 
     statement = json.loads(payload_bytes)
+    reject_unknown_intoto_fields(statement)
     stmt_type = statement.get("_type")
     if (
         policy.in_toto_statement_types_allowed is not None

--- a/src/tinfoil/conformance/sigstore.py
+++ b/src/tinfoil/conformance/sigstore.py
@@ -18,7 +18,11 @@ from sigstore.verify.policy import (
 )
 
 from ..attestation import Measurement, PredicateType
-from ..sigstore import OIDCIssuerV2Preferred, reject_duplicate_sct_logs
+from ..sigstore import (
+    OIDCIssuerV2Preferred,
+    reject_duplicate_sct_logs,
+    reject_legacy_bundle_format,
+)
 
 OIDC_ISSUER = "https://token.actions.githubusercontent.com"
 
@@ -103,6 +107,10 @@ def verify_sigstore_bundle_with_policy(
         trusted_root = TrustedRoot.from_file(tr_path)
 
     verifier = Verifier(trusted_root=trusted_root)
+
+    # SPEC §5.2: reject the legacy x509CertificateChain bundle layout.
+    reject_legacy_bundle_format(bundle_bytes)
+
     bundle = Bundle.from_json(bundle_bytes)
 
     # SPEC §5.2: reject duplicate-log SCTs before signature/SCT verification.

--- a/src/tinfoil/conformance/sigstore.py
+++ b/src/tinfoil/conformance/sigstore.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+
+from sigstore.errors import VerificationError
+from sigstore.models import Bundle, TrustedRoot
+from sigstore.verify import Verifier
+from sigstore.verify.policy import (
+    AllOf,
+    Certificate,
+    ExtensionNotFound,
+    GitHubWorkflowRepository,
+    OIDCIssuer,
+    _OIDC_GITHUB_WORKFLOW_REF_OID,
+)
+
+from ..attestation import Measurement, PredicateType
+
+OIDC_ISSUER = "https://token.actions.githubusercontent.com"
+
+
+@dataclass
+class SigstorePolicy:
+    oidc_issuer: str
+    workflow_ref_prefix: str
+    workflow_repository: str
+    predicate_types_allowed: list[str] | None
+    in_toto_statement_types_allowed: list[str] | None
+    payload_type: str
+
+
+def default_sigstore_policy(repo: str) -> SigstorePolicy:
+    return SigstorePolicy(
+        oidc_issuer=OIDC_ISSUER,
+        workflow_ref_prefix="refs/tags/",
+        workflow_repository=repo,
+        predicate_types_allowed=[
+            "https://tinfoil.sh/predicate/snp-tdx-multiplatform/v1",
+        ],
+        in_toto_statement_types_allowed=[
+            "https://in-toto.io/Statement/v0.1",
+            "https://in-toto.io/Statement/v1",
+        ],
+        payload_type="application/vnd.in-toto+json",
+    )
+
+
+@dataclass
+class SigstoreVerification:
+    measurement: Measurement
+    predicate_type: str
+    in_toto_statement_type: str
+    subject_name: str
+    subject_digest_sha256_hex: str
+    cert_oidc_issuer: str
+    cert_workflow_repository: str
+    cert_workflow_signer_uri: str
+    rekor_log_id_hex: str | None = None
+    rekor_integrated_time_unix: int | None = None
+    tlog_entry_count: int = 0
+    sct_count: int | None = None
+
+
+class GitHubWorkflowRefPrefix:
+    def __init__(self, prefix: str) -> None:
+        self._prefix = prefix
+
+    def verify(self, cert: Certificate) -> None:
+        try:
+            ext = cert.extensions.get_extension_for_oid(
+                _OIDC_GITHUB_WORKFLOW_REF_OID
+            ).value
+            ext_value = ext.value.decode()
+            if not ext_value.startswith(self._prefix):
+                raise VerificationError(
+                    "WORKFLOW_REF_PREFIX_MISMATCH: cert workflow ref "
+                    f"{ext_value!r} does not start with policy.workflow_ref_prefix "
+                    f"{self._prefix!r}"
+                )
+        except ExtensionNotFound:
+            raise VerificationError(
+                "WORKFLOW_REF_PREFIX_MISMATCH: Certificate does not contain "
+                "GitHubWorkflowRef "
+                f"({_OIDC_GITHUB_WORKFLOW_REF_OID.dotted_string}) extension"
+            )
+
+
+def verify_sigstore_bundle_with_policy(
+    bundle_bytes: bytes,
+    expected_digest_sha256_hex: str,
+    policy: SigstorePolicy,
+    trust_root_json: str,
+) -> SigstoreVerification:
+    """Conformance-only Sigstore verifier with injected policy and trust root."""
+    with tempfile.TemporaryDirectory(prefix="tinfoil-conformance-") as tdir:
+        tr_path = os.path.join(tdir, "trusted_root.json")
+        with open(tr_path, "w") as f:
+            f.write(trust_root_json)
+        trusted_root = TrustedRoot.from_file(tr_path)
+
+    verifier = Verifier(trusted_root=trusted_root)
+    bundle = Bundle.from_json(bundle_bytes)
+
+    cert_policy = AllOf(
+        [
+            OIDCIssuer(policy.oidc_issuer),
+            GitHubWorkflowRepository(policy.workflow_repository),
+            GitHubWorkflowRefPrefix(policy.workflow_ref_prefix),
+        ]
+    )
+    payload_type, payload_bytes = verifier.verify_dsse(bundle, cert_policy)
+
+    if payload_type != policy.payload_type:
+        raise ValueError(
+            f"PAYLOAD_TYPE_MISMATCH: DSSE payload_type {payload_type!r} does "
+            f"not equal policy.payload_type {policy.payload_type!r}"
+        )
+
+    statement = json.loads(payload_bytes)
+    stmt_type = statement.get("_type")
+    if (
+        policy.in_toto_statement_types_allowed is not None
+        and stmt_type not in policy.in_toto_statement_types_allowed
+    ):
+        raise ValueError(
+            "IN_TOTO_STATEMENT_TYPE_NOT_ALLOWED: in-toto statement _type "
+            f"{stmt_type!r} not in policy.in_toto_statement_types_allowed"
+        )
+
+    subjects = statement.get("subject")
+    if not subjects or not isinstance(subjects, list):
+        raise ValueError("SUBJECT_MISSING: in-toto statement has no subject array")
+    subject0 = subjects[0]
+    if (
+        not isinstance(subject0, dict)
+        or not isinstance(subject0.get("digest"), dict)
+        or "sha256" not in subject0["digest"]
+    ):
+        raise ValueError("SUBJECT_MISSING: subject[0].digest.sha256 missing")
+
+    bundle_digest = subject0["digest"]["sha256"]
+    if bundle_digest.lower() != expected_digest_sha256_hex.lower():
+        raise ValueError(
+            "SUBJECT_DIGEST_MISMATCH: bundle subject digest "
+            f"{bundle_digest!r} does not equal expected "
+            f"{expected_digest_sha256_hex!r}"
+        )
+
+    predicate_type = statement.get("predicateType")
+    if (
+        policy.predicate_types_allowed is not None
+        and predicate_type not in policy.predicate_types_allowed
+    ):
+        raise ValueError(
+            f"PREDICATE_TYPE_NOT_ALLOWED: predicate type {predicate_type!r} "
+            "not in policy.predicate_types_allowed"
+        )
+
+    predicate_fields = statement.get("predicate") or {}
+    if predicate_type == "https://tinfoil.sh/predicate/snp-tdx-multiplatform/v1":
+        measurement = _extract_multiplatform_measurement(predicate_fields)
+    else:
+        raise ValueError(
+            "PREDICATE_MEASUREMENT_INVALID: predicate type "
+            f"{predicate_type!r} allowed by policy but extraction not implemented "
+            "in tinfoil-python"
+        )
+
+    cert_oidc, cert_repo, cert_signer_uri = _extract_cert_info(bundle_bytes)
+    rekor_log_id_hex, rekor_integrated_time, tlog_count = (
+        _extract_tlog_observables(bundle_bytes)
+    )
+
+    return SigstoreVerification(
+        measurement=measurement,
+        predicate_type=predicate_type,
+        in_toto_statement_type=stmt_type or "",
+        subject_name=subject0.get("name", "") if isinstance(subject0, dict) else "",
+        subject_digest_sha256_hex=bundle_digest.lower(),
+        cert_oidc_issuer=cert_oidc,
+        cert_workflow_repository=cert_repo,
+        cert_workflow_signer_uri=cert_signer_uri,
+        rekor_log_id_hex=rekor_log_id_hex,
+        rekor_integrated_time_unix=rekor_integrated_time,
+        tlog_entry_count=tlog_count,
+        sct_count=_extract_sct_count(bundle_bytes),
+    )
+
+
+def _extract_multiplatform_measurement(predicate: dict) -> Measurement:
+    snp = predicate.get("snp_measurement")
+    if not isinstance(snp, str):
+        raise ValueError(
+            "PREDICATE_MEASUREMENT_INVALID: SnpTdxMultiPlatformV1 "
+            "missing snp_measurement"
+        )
+    tdx = predicate.get("tdx_measurement") or {}
+    rtmr1 = tdx.get("rtmr1")
+    rtmr2 = tdx.get("rtmr2")
+    if not isinstance(rtmr1, str):
+        raise ValueError(
+            "PREDICATE_MEASUREMENT_INVALID: SnpTdxMultiPlatformV1 "
+            "missing tdx_measurement.rtmr1"
+        )
+    if not isinstance(rtmr2, str):
+        raise ValueError(
+            "PREDICATE_MEASUREMENT_INVALID: SnpTdxMultiPlatformV1 "
+            "missing tdx_measurement.rtmr2"
+        )
+    return Measurement(
+        type=PredicateType.SNP_TDX_MULTIPLATFORM_v1,
+        registers=[snp, rtmr1, rtmr2],
+    )
+
+
+def _extract_cert_info(bundle_bytes: bytes) -> tuple[str, str, str]:
+    from cryptography import x509 as _x509
+
+    try:
+        bundle = json.loads(bundle_bytes)
+        cert_b64 = (
+            bundle.get("verificationMaterial", {})
+            .get("certificate", {})
+            .get("rawBytes")
+        )
+        if not isinstance(cert_b64, str):
+            return ("", "", "")
+        cert = _x509.load_der_x509_certificate(base64.b64decode(cert_b64))
+        oidc = _read_str_ext(cert, "1.3.6.1.4.1.57264.1.8") or _read_str_ext(
+            cert, "1.3.6.1.4.1.57264.1.1"
+        )
+        repo = _read_str_ext(cert, "1.3.6.1.4.1.57264.1.5")
+        signer = _read_str_ext(cert, "1.3.6.1.4.1.57264.1.9")
+        return (oidc or "", repo or "", signer or "")
+    except Exception:
+        return ("", "", "")
+
+
+def _read_str_ext(cert, oid_dotted: str) -> str | None:
+    from cryptography.x509 import ObjectIdentifier
+
+    try:
+        ext = cert.extensions.get_extension_for_oid(ObjectIdentifier(oid_dotted))
+    except Exception:
+        return None
+    raw = ext.value.value
+    if raw.startswith(b"\x0c"):
+        if len(raw) < 2:
+            return raw.decode(errors="ignore")
+        n = raw[1]
+        if n < 0x80:
+            return raw[2 : 2 + n].decode(errors="ignore")
+        nb = n & 0x7F
+        if len(raw) < 2 + nb:
+            return raw.decode(errors="ignore")
+        total = int.from_bytes(raw[2 : 2 + nb], "big")
+        return raw[2 + nb : 2 + nb + total].decode(errors="ignore")
+    return raw.decode(errors="ignore")
+
+
+def _extract_tlog_observables(
+    bundle_bytes: bytes,
+) -> tuple[str | None, int | None, int]:
+    try:
+        bundle = json.loads(bundle_bytes)
+        entries = bundle.get("verificationMaterial", {}).get("tlogEntries") or []
+        if len(entries) == 0:
+            return (None, None, 0)
+        first = entries[0]
+        log_id_b64 = (first.get("logId") or {}).get("keyId")
+        log_id_hex = (
+            base64.b64decode(log_id_b64).hex()
+            if isinstance(log_id_b64, str)
+            else None
+        )
+        integrated_time = first.get("integratedTime")
+        if isinstance(integrated_time, str):
+            try:
+                integrated_time = int(integrated_time)
+            except ValueError:
+                integrated_time = None
+        elif not isinstance(integrated_time, int):
+            integrated_time = None
+        return (log_id_hex, integrated_time, len(entries))
+    except Exception:
+        return (None, None, 0)
+
+
+def _extract_sct_count(bundle_bytes: bytes) -> int | None:
+    try:
+        bundle = json.loads(bundle_bytes)
+        cert_b64 = (
+            bundle.get("verificationMaterial", {})
+            .get("certificate", {})
+            .get("rawBytes")
+        )
+        if not isinstance(cert_b64, str):
+            return None
+        from cryptography import x509 as _x509
+        from cryptography.x509 import ObjectIdentifier
+
+        cert = _x509.load_der_x509_certificate(base64.b64decode(cert_b64))
+        try:
+            ext = cert.extensions.get_extension_for_oid(
+                ObjectIdentifier("1.3.6.1.4.1.11129.2.4.2")
+            )
+        except Exception:
+            return 0
+        if hasattr(ext.value, "__iter__"):
+            return len(list(ext.value))
+        return None
+    except Exception:
+        return None

--- a/src/tinfoil/conformance/sigstore.py
+++ b/src/tinfoil/conformance/sigstore.py
@@ -18,7 +18,7 @@ from sigstore.verify.policy import (
 )
 
 from ..attestation import Measurement, PredicateType
-from ..sigstore import OIDCIssuerV2Preferred
+from ..sigstore import OIDCIssuerV2Preferred, reject_duplicate_sct_logs
 
 OIDC_ISSUER = "https://token.actions.githubusercontent.com"
 
@@ -104,6 +104,9 @@ def verify_sigstore_bundle_with_policy(
 
     verifier = Verifier(trusted_root=trusted_root)
     bundle = Bundle.from_json(bundle_bytes)
+
+    # SPEC §5.2: reject duplicate-log SCTs before signature/SCT verification.
+    reject_duplicate_sct_logs(bundle)
 
     cert_policy = AllOf(
         [

--- a/src/tinfoil/conformance/sigstore.py
+++ b/src/tinfoil/conformance/sigstore.py
@@ -14,11 +14,11 @@ from sigstore.verify.policy import (
     Certificate,
     ExtensionNotFound,
     GitHubWorkflowRepository,
-    OIDCIssuer,
     _OIDC_GITHUB_WORKFLOW_REF_OID,
 )
 
 from ..attestation import Measurement, PredicateType
+from ..sigstore import OIDCIssuerV2Preferred
 
 OIDC_ISSUER = "https://token.actions.githubusercontent.com"
 
@@ -107,7 +107,7 @@ def verify_sigstore_bundle_with_policy(
 
     cert_policy = AllOf(
         [
-            OIDCIssuer(policy.oidc_issuer),
+            OIDCIssuerV2Preferred(policy.oidc_issuer),
             GitHubWorkflowRepository(policy.workflow_repository),
             GitHubWorkflowRefPrefix(policy.workflow_ref_prefix),
         ]


### PR DESCRIPTION
Follows the other SDKs to implement conformance testing. Build the dedicated CLI and add a CI job.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross‑SDK `tinfoil-conformance` CLI and CI to verify Sigstore, TDX, and SEV‑SNP against the policy layer, plus EHBP key binding. Now runs the full TDX path (structural + collateral), prefers OIDC V2, enforces SPEC‑level bundle/statement checks, and wires verify‑full for SEV and TDX.

- New Features
  - `tinfoil-conformance` CLI: `capabilities`, `verify-sigstore`, `verify-measurement`, `verify-hardware-measurements`, `verify-attestation-tdx` (adapter/public API; structural + full collateral), `verify-attestation-sev` (adapter/public API), `verify-full` (standard/bundle/pinned; Sigstore → SEV/TDX), `verify-ehbp-key-binding`.
  - Sigstore: `verify_sigstore_bundle_with_policy` (hermetic `sigstore.TrustedRoot`), OIDC issuer V2 preferred (V1 fallback), emits observables, rejects duplicate‑log SCTs, legacy `x509CertificateChain` bundles, and unknown top‑level in‑toto fields; checks only `subject[0]`.
  - TDX: quote parse/crypto checks; full §4.7 TCB evaluation with injected collateral, Intel root override, and time override; §4.8 pins + normative defaults; public‑API path with config re‑baseline and §4.7.7 accepted‑QV‑results gating; accepts non‑terminal TCB.
  - SEV‑SNP: v3 report verification with injected VCEK and embedded/injected ASK/ARK; §3.4 cross‑checks + MIGRATE_MA rejection; public‑API path with post‑verify §3.7 policy pins; time override is system‑clock‑only.
  - `verify-full`: chains Sigstore → SEV/TDX, compares measurements (SPEC §11), supports standard/bundle/pinned, returns a stage‑scoped rejection/final fingerprint.
  - EHBP key binding: validates HPKE key from `report_data[32:64]`; rejects on mismatch.
  - Capabilities: stages `verify-measurement`, `verify-hardware-measurements`, `verify-full`, `verify-ehbp-key-binding`; flows `["standard","bundle","pinned"]`; Sigstore `{oidc_issuer_v2_preferred=true, rejects_duplicate_sct_log=true, scts_count_distinguish_missing_vs_duplicate=true, checks_only_subject_0=true, in_toto_statement_tolerates_extra_fields=false}`; TDX `{supported, injected_collateral_supported, extended_td_checks_supported, tcb_evaluation_supported, accepts_non_terminal_tcb_statuses=true, verification_time_override="supported", verify_full_supported=true}`; SEV `{public_api_hooks_supported=true, verification_time_override="system-clock-only"}`; `measurement.compare_multiplatform_to_tdx_supported=true`; `transport_ehbp_supported=true`; `ehbp.key_binding_supported=true`.

- Refactors
  - Expanded Sigstore/TDX/SEV error classifiers to SPEC‑coded rejections; strict prefix match for `workflow_ref_prefix` (SPEC §5.3).
  - Isolated Python Sigstore hooks under `tinfoil.conformance.sigstore`; added CI workflow to run the cross‑SDK suite against the `tinfoil-conformance` binary.

<sup>Written for commit 9a967242d94b3205f171c2ef7b8a8071061bc396. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-python/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

