### PR TITLE
chore: bump idna package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,6 @@ asyncio_default_fixture_loop_scope = "function"
 
 [tool.uv]
 exclude-newer = "4 days"
+constraint-dependencies = [
+    "idna>=3.15", # GHSA-65pc-fj4g-8rjx
+]

--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,11 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-05-08T19:28:06.512104Z"
+exclude-newer = "2026-05-18T19:45:30.83521Z"
 exclude-newer-span = "P4D"
+
+[manifest]
+constraints = [{ name = "idna", specifier = ">=3.15" }]
 
 [[package]]
 name = "annotated-types"
@@ -397,11 +400,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Addresses GHSA-65pc-fj4g-8rjx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `idna` to >=3.15 to fix GHSA-65pc-fj4g-8rjx. Adds a uv constraint and refreshes the lockfile to pull the patched release.

- **Dependencies**
  - Add `[tool.uv].constraint-dependencies` for `idna>=3.15` in `pyproject.toml`.
  - Update `uv.lock` to `idna` 3.15 and refresh metadata.

<sup>Written for commit 325a4ca542b317cac2cb301dd6f0ad3a40b79ff7. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-python/pull/94?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

