### PR TITLE
Add support for EHBP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requires-python = ">=3.10"
 dependencies = [
     "openai>=1.63.0",
     "httpx>=0.28",
+    "tinfoil-ehbp>=0.2.3",
     "requests>=2.31.0",
     "cryptography>=42.0.0",
     "pyOpenSSL>=25.0.0",
@@ -40,6 +41,9 @@ asyncio_default_fixture_loop_scope = "function"
 
 [tool.uv]
 exclude-newer = "4 days"
+# tinfoil-ehbp is a first-party package; allow recently published releases past
+# the global exclude-newer cutoff.
+exclude-newer-package = { "tinfoil-ehbp" = "2026-06-04T00:00:00Z" }
 constraint-dependencies = [
     "idna>=3.15", # GHSA-65pc-fj4g-8rjx
 ]

--- a/src/tinfoil/__init__.py
+++ b/src/tinfoil/__init__.py
@@ -5,7 +5,13 @@ from openai.resources.embeddings import Embeddings as OpenAIEmbeddings
 from openai.resources.audio import Audio as OpenAIAudio
 import httpx
 
-from .client import SecureClient, VerificationDocument, get_router_address
+from .client import (
+    DEFAULT_TRANSPORT_MODE,
+    SecureClient,
+    TransportMode,
+    VerificationDocument,
+    get_router_address,
+)
 
 class TinfoilAI:
     chat: OpenAIChat
@@ -21,6 +27,7 @@ class TinfoilAI:
         api_key: str = "tinfoil",
         measurement: Optional[dict] = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+        transport: TransportMode = DEFAULT_TRANSPORT_MODE,
     ):
         if measurement is not None:
             repo = ""
@@ -35,7 +42,7 @@ class TinfoilAI:
         
         self.enclave = enclave
         self.api_key = api_key
-        self._secure_client = SecureClient(enclave, repo, measurement)
+        self._secure_client = SecureClient(enclave, repo, measurement, transport=transport)
         secure_http = self._secure_client.make_secure_http_client()
         self.client = OpenAI(
             base_url=f"https://{enclave}/v1/",
@@ -68,6 +75,7 @@ class AsyncTinfoilAI:
         api_key: str = "tinfoil",
         measurement: Optional[dict] = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+        transport: TransportMode = DEFAULT_TRANSPORT_MODE,
     ):
         if measurement is not None:
             repo = ""
@@ -83,7 +91,7 @@ class AsyncTinfoilAI:
         self.enclave = enclave
         self.api_key = api_key
         # verifier client remains sync; only used to fetch the expected public key
-        self._secure_client = SecureClient(enclave, repo, measurement)
+        self._secure_client = SecureClient(enclave, repo, measurement, transport=transport)
         async_http = self._secure_client.make_secure_async_http_client()
         self.client = AsyncOpenAI(
             base_url=f"https://{enclave}/v1/",
@@ -120,7 +128,7 @@ class _HTTPSecureClient:
         return self._http_client.post(url, headers=headers, data=data, json=json, timeout=timeout)
 
 
-def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", measurement: Optional[dict] = None):
+def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE):
     """Create a secure HTTP client for direct GET/POST through the Tinfoil enclave."""
     if measurement is not None:
         repo = ""
@@ -133,7 +141,7 @@ def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model
     if enclave == "" or enclave is None:
         enclave = get_router_address()
 
-    tf_client = SecureClient(enclave, repo, measurement)
+    tf_client = SecureClient(enclave, repo, measurement, transport=transport)
     return _HTTPSecureClient(enclave, tf_client)
 
-__all__ = ["TinfoilAI", "AsyncTinfoilAI", "NewSecureClient", "SecureClient", "VerificationDocument"]
+__all__ = ["TinfoilAI", "AsyncTinfoilAI", "NewSecureClient", "SecureClient", "VerificationDocument", "TransportMode"]

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -400,6 +400,7 @@ class SecureClient:
         self.transport = transport
         self._ground_truth: Optional[GroundTruth] = None
         self._verification_document: Optional[VerificationDocument] = None
+        self._low_level_http_client: Optional[httpx.Client] = None
 
     @property
     def ground_truth(self) -> Optional[GroundTruth]:
@@ -642,27 +643,55 @@ class SecureClient:
             return self._ground_truth
 
     def get_http_client(self) -> urllib.request.OpenerDirector:
-        """Returns an HTTP client that only accepts TLS connections to the verified enclave"""
+        """
+        Returns a urllib opener that pins the enclave's TLS certificate.
+
+        This accessor is specific to the "tls" transport mode. In the default
+        "ehbp" mode there is no certificate to pin (the connection is
+        proxy-friendly and the body is encrypted end-to-end instead), so use
+        make_secure_http_client() or construct the client with transport="tls".
+        """
         if not self._ground_truth:
             self._ground_truth = self.verify()
-        
+
+        if self.transport == "ehbp":
+            raise ValueError(
+                "get_http_client() pins the enclave's TLS certificate and is "
+                "only available with transport='tls'. Use "
+                "make_secure_http_client() for the EHBP transport."
+            )
+
         handler = TLSBoundHTTPSHandler(self._ground_truth.public_key)
         return urllib.request.build_opener(handler)
 
+    def _secure_http_client(self) -> httpx.Client:
+        """Lazily build the mode-aware httpx client backing get()/post()."""
+        if self._low_level_http_client is None:
+            self._low_level_http_client = self.make_secure_http_client()
+        return self._low_level_http_client
+
     def make_request(self, req: urllib.request.Request) -> Response:
-        """Makes an HTTP request using the secure client"""
-        client = self.get_http_client()
-        
+        """
+        Makes an HTTP request using the secure client, honoring the configured
+        transport mode: in "ehbp" mode the request body is encrypted end-to-end
+        to the enclave, and in "tls" mode the enclave's certificate is pinned.
+        """
+        url = req.full_url
         # If URL doesn't have a host, assume it's relative to the enclave
-        if not urlparse(req.full_url).netloc:
-            req.full_url = f"https://{self.enclave}{req.full_url}"
-        
-        with client.open(req) as resp:
-            return Response(
-                status=f"{resp.status} {resp.reason}",
-                status_code=resp.status,
-                body=resp.read()
-            )
+        if not urlparse(url).netloc:
+            url = f"https://{self.enclave}{url}"
+
+        response = self._secure_http_client().request(
+            req.get_method(),
+            url,
+            headers=dict(req.header_items()),
+            content=req.data,
+        )
+        return Response(
+            status=f"{response.status_code} {response.reason_phrase}",
+            status_code=response.status_code,
+            body=response.content,
+        )
 
     def post(self, url: str, headers: Dict[str, str], body: bytes) -> Response:
         """Makes an HTTP POST request"""

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -15,6 +15,12 @@ import cryptography.x509
 from cryptography.hazmat.primitives.serialization import PublicFormat, Encoding
 import hashlib
 
+from ehbp import (
+    AsyncEHBPTransport,
+    EHBPTransport,
+    KeyConfigMismatchError,
+)
+
 from .attestation import fetch_attestation, TDX_TYPES
 from .attestation.attestation_tdx import verify_tdx_hardware
 from .attestation.types import Measurement, HardwareMeasurement, Verification
@@ -26,6 +32,15 @@ _CERTIFICATE_VERIFY_ERROR_MARKERS = (
     "certificate_verify_failed",
     "certificate verify failed",
 )
+
+# Transport mode for secure communication with the enclave.
+#
+# - "ehbp" encrypts request bodies end-to-end with HPKE via the Encrypted HTTP
+#   Body Protocol, so only the verified enclave can decrypt them. It works
+#   through proxies and is the default.
+# - "tls" pins the enclave's TLS certificate, which requires a direct connection.
+TransportMode = Literal["ehbp", "tls"]
+DEFAULT_TRANSPORT_MODE: TransportMode = "ehbp"
 
 
 class _PinMismatchError(ValueError):
@@ -45,6 +60,7 @@ class GroundTruth:
     public_key: str  # Changed from cert_fingerprint to public_key
     digest: str
     measurement: str
+    hpke_public_key: str = ""
 
 
 @dataclass
@@ -263,10 +279,106 @@ class _AsyncReVerifyingTransport(httpx.AsyncBaseTransport):
         await self._inner.aclose()
 
 
+class _EHBPReVerifyingTransport(httpx.BaseTransport):
+    """
+    Wraps an EHBP transport and transparently re-verifies the enclave's
+    attestation when the server rotates its HPKE key (surfaced as
+    :class:`ehbp.KeyConfigMismatchError`).
+
+    The mismatch is reported before the request is processed, so it is safe to
+    rebuild the transport from the freshly attested key and retry the request
+    once. This mirrors the certificate rotation handling of
+    :class:`_ReVerifyingTransport`.
+    """
+
+    def __init__(self, secure_client: "SecureClient", inner: httpx.BaseTransport):
+        self._secure_client = secure_client
+        self._inner = inner
+        self._lock = threading.Lock()
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        inner = self._inner
+        try:
+            return inner.handle_request(request)
+        except KeyConfigMismatchError:
+            old_inner: Optional[httpx.BaseTransport] = None
+            retry_inner: Optional[httpx.BaseTransport] = None
+            reverify_failed = False
+            with self._lock:
+                if self._inner is inner:
+                    try:
+                        retry_inner = self._secure_client._build_ehbp_sync_transport()
+                    except Exception:
+                        # Re-verification failed; surface the original mismatch.
+                        reverify_failed = True
+                    else:
+                        old_inner = self._inner
+                        self._inner = retry_inner
+                else:
+                    retry_inner = self._inner
+
+            if reverify_failed:
+                raise
+
+            assert retry_inner is not None
+            try:
+                return retry_inner.handle_request(request)
+            finally:
+                if old_inner is not None:
+                    with contextlib.suppress(Exception):
+                        old_inner.close()
+
+    def close(self) -> None:
+        self._inner.close()
+
+
+class _AsyncEHBPReVerifyingTransport(httpx.AsyncBaseTransport):
+    """Async counterpart to :class:`_EHBPReVerifyingTransport`."""
+
+    def __init__(self, secure_client: "SecureClient", inner: httpx.AsyncBaseTransport):
+        self._secure_client = secure_client
+        self._inner = inner
+        self._lock = asyncio.Lock()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        inner = self._inner
+        try:
+            return await inner.handle_async_request(request)
+        except KeyConfigMismatchError:
+            old_inner: Optional[httpx.AsyncBaseTransport] = None
+            retry_inner: Optional[httpx.AsyncBaseTransport] = None
+            reverify_failed = False
+            async with self._lock:
+                if self._inner is inner:
+                    try:
+                        retry_inner = await self._secure_client._build_ehbp_async_transport()
+                    except Exception:
+                        reverify_failed = True
+                    else:
+                        old_inner = self._inner
+                        self._inner = retry_inner
+                else:
+                    retry_inner = self._inner
+
+            if reverify_failed:
+                raise
+
+            assert retry_inner is not None
+            try:
+                return await retry_inner.handle_async_request(request)
+            finally:
+                if old_inner is not None:
+                    with contextlib.suppress(Exception):
+                        await old_inner.aclose()
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
 class SecureClient:
     """A client that verifies and communicates with secure enclaves"""
     
-    def __init__(self, enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", measurement: Optional[dict] = None):
+    def __init__(self, enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE):
         # Hardcoded measurement takes precedence over repo
         if measurement is not None:
             repo = ""
@@ -275,6 +387,9 @@ class SecureClient:
         if measurement is None and (repo == "" or repo is None):
             raise ValueError("Must provide either 'measurement' or 'repo' parameter for verification.")
 
+        if transport not in ("ehbp", "tls"):
+            raise ValueError(f"Unknown transport mode: {transport!r}. Use 'ehbp' or 'tls'.")
+
         # If enclave is empty, fetch a random one from the routers API
         if enclave == "" or enclave is None:
             enclave = get_router_address()
@@ -282,6 +397,7 @@ class SecureClient:
         self.enclave = enclave
         self.repo = repo
         self.measurement = measurement
+        self.transport = transport
         self._ground_truth: Optional[GroundTruth] = None
         self._verification_document: Optional[VerificationDocument] = None
 
@@ -350,15 +466,44 @@ class SecureClient:
         ctx = self._build_async_ssl_context(expected_fp)
         return httpx.AsyncHTTPTransport(verify=ctx)
 
+    def _require_hpke_public_key(self) -> str:
+        """Re-run attestation and return the attested HPKE public key."""
+        ground_truth = self.verify()
+        if not ground_truth.hpke_public_key:
+            raise ValueError(
+                "Enclave did not expose an HPKE public key; cannot use the "
+                "EHBP transport. Use transport='tls' instead."
+            )
+        return ground_truth.hpke_public_key
+
+    def _build_ehbp_sync_transport(self) -> httpx.BaseTransport:
+        """Build a sync EHBP transport bound to the attested HPKE public key."""
+        hpke_public_key = self._require_hpke_public_key()
+        return EHBPTransport.from_public_key_hex(hpke_public_key, inner=httpx.HTTPTransport())
+
+    async def _build_ehbp_async_transport(self) -> httpx.AsyncBaseTransport:
+        """Build an async EHBP transport without blocking the event loop."""
+        hpke_public_key = await asyncio.to_thread(self._require_hpke_public_key)
+        return AsyncEHBPTransport.from_public_key_hex(hpke_public_key, inner=httpx.AsyncHTTPTransport())
+
     def make_secure_http_client(self) -> httpx.Client:
         """
-        Build an httpx.Client that pins the enclave's TLS cert.
+        Build an httpx.Client that securely communicates with the enclave.
+
+        In the default "ehbp" transport mode, request bodies are encrypted
+        end-to-end with the enclave's attested HPKE public key. In "tls" mode,
+        the enclave's TLS certificate is pinned instead.
 
         The returned client is suitable for long-lived use: if the enclave
-        rotates its TLS certificate (for example after a server-side restart),
-        the underlying transport will automatically re-verify attestation and
-        retry the request once.
+        rotates its key (for example after a server-side restart), the
+        underlying transport automatically re-verifies attestation and retries
+        the request once.
         """
+        if self.transport == "ehbp":
+            inner = self._build_ehbp_sync_transport()
+            transport = _EHBPReVerifyingTransport(self, inner)
+            return httpx.Client(transport=transport, follow_redirects=True)
+
         expected_fp = self.verify().public_key
         ctx = self._build_sync_ssl_context(expected_fp)
         inner = httpx.HTTPTransport(verify=ctx)
@@ -367,13 +512,23 @@ class SecureClient:
 
     def make_secure_async_http_client(self) -> httpx.AsyncClient:
         """
-        Build an httpx.AsyncClient that pins the enclave's TLS cert.
+        Build an httpx.AsyncClient that securely communicates with the enclave.
+
+        In the default "ehbp" transport mode, request bodies are encrypted
+        end-to-end with the enclave's attested HPKE public key. In "tls" mode,
+        the enclave's TLS certificate is pinned instead.
 
         The returned client is suitable for long-lived use: if the enclave
-        rotates its TLS certificate (for example after a server-side restart),
-        the underlying transport will automatically re-verify attestation and
-        retry the request once.
+        rotates its key (for example after a server-side restart), the
+        underlying transport automatically re-verifies attestation and retries
+        the request once.
         """
+        if self.transport == "ehbp":
+            hpke_public_key = self._require_hpke_public_key()
+            inner = AsyncEHBPTransport.from_public_key_hex(hpke_public_key, inner=httpx.AsyncHTTPTransport())
+            transport = _AsyncEHBPReVerifyingTransport(self, inner)
+            return httpx.AsyncClient(transport=transport, follow_redirects=True)
+
         expected_fp = self.verify().public_key
         ctx = self._build_async_ssl_context(expected_fp)
         inner = httpx.AsyncHTTPTransport(verify=ctx)
@@ -440,6 +595,7 @@ class SecureClient:
                 public_key=verification.public_key_fp,
                 digest="pinned_no_digest",
                 measurement=verification.measurement,
+                hpke_public_key=verification.hpke_public_key or "",
             )
             return self._ground_truth
         else:
@@ -481,6 +637,7 @@ class SecureClient:
                 public_key=verification.public_key_fp,
                 digest=digest,
                 measurement=verification.measurement,
+                hpke_public_key=verification.hpke_public_key or "",
             )
             return self._ground_truth
 

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -677,15 +677,25 @@ class SecureClient:
         to the enclave, and in "tls" mode the enclave's certificate is pinned.
         """
         url = req.full_url
+        parsed = urlparse(url)
         # If URL doesn't have a host, assume it's relative to the enclave
-        if not urlparse(url).netloc:
+        if not parsed.netloc:
             url = f"https://{self.enclave}{url}"
+        elif parsed.hostname != urlparse(f"//{self.enclave}").hostname:
+            # EHBP encrypts only the body; headers (which may carry the API key)
+            # reach the destination in plaintext, so never send them to a host
+            # other than the attested enclave this client is bound to.
+            raise ValueError(
+                f"refusing to send request to host {parsed.hostname!r}: this "
+                f"secure client is bound to enclave {self.enclave!r}"
+            )
 
         response = self._secure_http_client().request(
             req.get_method(),
             url,
             headers=dict(req.header_items()),
             content=req.data,
+            timeout=None,  # match the prior urllib path, which had no timeout
         )
         return Response(
             status=f"{response.status_code} {response.reason_phrase}",

--- a/tests/test_attestation_flow.py
+++ b/tests/test_attestation_flow.py
@@ -121,13 +121,16 @@ def test_sync_pinned_client_rejects_wrong_host():
     """
     A client pinned to the enclave's cert must reject connections
     to a different host (whose cert won't match the pinned fingerprint).
+
+    Certificate pinning is a property of the "tls" transport; the default
+    "ehbp" transport is intentionally proxy-friendly and does not pin the host.
     """
     try:
         enclave = get_router_address()
     except Exception as e:
         pytest.skip(f"Could not fetch router address from ATC service: {e}")
 
-    client = SecureClient(enclave=enclave, repo=REPO)
+    client = SecureClient(enclave=enclave, repo=REPO, transport="tls")
     http_client = client.make_secure_http_client()
 
     try:
@@ -142,13 +145,16 @@ async def test_async_pinned_client_rejects_wrong_host():
     """
     The async pinned client must reject connections to a host
     whose cert doesn't match the pinned fingerprint.
+
+    Certificate pinning is a property of the "tls" transport; the default
+    "ehbp" transport is intentionally proxy-friendly and does not pin the host.
     """
     try:
         enclave = get_router_address()
     except Exception as e:
         pytest.skip(f"Could not fetch router address from ATC service: {e}")
 
-    client = SecureClient(enclave=enclave, repo=REPO)
+    client = SecureClient(enclave=enclave, repo=REPO, transport="tls")
     http_client = client.make_secure_async_http_client()
 
     try:

--- a/tests/test_constructor_timeout.py
+++ b/tests/test_constructor_timeout.py
@@ -5,10 +5,11 @@ import tinfoil
 
 
 class FakeSecureClient:
-    def __init__(self, enclave, repo, measurement):
+    def __init__(self, enclave, repo, measurement, transport="ehbp"):
         self.enclave = enclave
         self.repo = repo
         self.measurement = measurement
+        self.transport = transport
 
     def make_secure_http_client(self):
         return "sync-http-client"

--- a/tests/test_ehbp_transport.py
+++ b/tests/test_ehbp_transport.py
@@ -108,6 +108,39 @@ class TestTransportSelection:
             inner.close()
 
 
+class TestLowLevelHonorsTransport:
+    """The low-level get()/post() path must respect the configured transport."""
+
+    def test_low_level_client_uses_ehbp_transport(self):
+        sc = _secure_client("ehbp")
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        client = sc._secure_http_client()
+        try:
+            assert isinstance(client._transport, _EHBPReVerifyingTransport)
+        finally:
+            client.close()
+
+    def test_low_level_client_uses_pinned_transport_in_tls_mode(self):
+        sc = _secure_client("tls")
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        client = sc._secure_http_client()
+        try:
+            assert isinstance(client._transport, _ReVerifyingTransport)
+        finally:
+            client.close()
+
+    def test_get_http_client_rejected_in_ehbp_mode(self):
+        sc = _secure_client("ehbp")
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        with pytest.raises(ValueError):
+            sc.get_http_client()
+
+    def test_get_http_client_allowed_in_tls_mode(self):
+        sc = _secure_client("tls")
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        assert sc.get_http_client() is not None
+
+
 class _RaiseKeyMismatch(httpx.BaseTransport):
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         request.read()  # EHBP consumes the body before reporting the mismatch
@@ -203,13 +236,24 @@ class TestAsyncReverify:
         asyncio.run(run())
 
 
+def _require_api_key() -> str:
+    """
+    Return TINFOIL_API_KEY, failing the test if it is missing.
+
+    Integration tests must not be silently skipped when a required secret is
+    absent: that hides misconfigured CI and lets coverage regress unnoticed.
+    """
+    api_key = os.getenv("TINFOIL_API_KEY")
+    if not api_key:
+        pytest.fail("TINFOIL_API_KEY must be set to run the integration tests")
+    return api_key
+
+
 @pytest.mark.integration
 class TestIntegration:
     @pytest.mark.parametrize("transport", ["ehbp", "tls"])
     def test_chat_completion(self, transport):
-        api_key = os.getenv("TINFOIL_API_KEY")
-        if not api_key:
-            pytest.skip("TINFOIL_API_KEY not set")
+        api_key = _require_api_key()
 
         client = TinfoilAI(api_key=api_key, transport=transport)
         response = client.chat.completions.create(
@@ -224,9 +268,7 @@ class TestIntegration:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("transport", ["ehbp", "tls"])
     async def test_async_streaming_chat_completion(self, transport):
-        api_key = os.getenv("TINFOIL_API_KEY")
-        if not api_key:
-            pytest.skip("TINFOIL_API_KEY not set")
+        api_key = _require_api_key()
 
         client = AsyncTinfoilAI(api_key=api_key, transport=transport)
         stream = await client.chat.completions.create(

--- a/tests/test_ehbp_transport.py
+++ b/tests/test_ehbp_transport.py
@@ -141,6 +141,41 @@ class TestLowLevelHonorsTransport:
         assert sc.get_http_client() is not None
 
 
+class TestMakeRequestHostBinding:
+    """make_request() must stay bound to the attested enclave (headers are not
+    encrypted by EHBP) and preserve the prior unbounded timeout."""
+
+    def _client_with_mock(self, transport: str = "ehbp"):
+        sc = _secure_client(transport)
+        http_client = MagicMock()
+        http_client.request.return_value = httpx.Response(200, content=b"ok")
+        sc._low_level_http_client = http_client
+        return sc, http_client
+
+    def test_rejects_absolute_url_to_foreign_host(self):
+        sc, http_client = self._client_with_mock()
+        with pytest.raises(ValueError, match="evil.example.com"):
+            sc.get("https://evil.example.com/v1/models")
+        http_client.request.assert_not_called()
+
+    def test_rejects_foreign_host_in_tls_mode_too(self):
+        sc, http_client = self._client_with_mock("tls")
+        with pytest.raises(ValueError):
+            sc.get("https://evil.example.com/v1/models")
+        http_client.request.assert_not_called()
+
+    def test_allows_absolute_url_to_enclave_host(self):
+        sc, http_client = self._client_with_mock()
+        resp = sc.get("https://enclave.test/v1/models")
+        assert resp.status_code == 200
+        assert http_client.request.call_args.args[1] == "https://enclave.test/v1/models"
+
+    def test_preserves_unbounded_timeout(self):
+        sc, http_client = self._client_with_mock()
+        sc.post("https://enclave.test/v1/chat/completions", headers={}, body=b"payload")
+        assert http_client.request.call_args.kwargs["timeout"] is None
+
+
 class _RaiseKeyMismatch(httpx.BaseTransport):
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         request.read()  # EHBP consumes the body before reporting the mismatch

--- a/tests/test_ehbp_transport.py
+++ b/tests/test_ehbp_transport.py
@@ -7,6 +7,7 @@ the server rotates its HPKE key (surfaced as KeyConfigMismatchError).
 """
 
 import asyncio
+import json
 import os
 from unittest.mock import AsyncMock, MagicMock
 
@@ -20,6 +21,7 @@ from tinfoil import AsyncTinfoilAI, SecureClient, TinfoilAI
 from tinfoil.client import (
     DEFAULT_TRANSPORT_MODE,
     GroundTruth,
+    get_router_address,
     _AsyncEHBPReVerifyingTransport,
     _EHBPReVerifyingTransport,
     _ReVerifyingTransport,
@@ -319,3 +321,54 @@ class TestIntegration:
             if chunk.choices and chunk.choices[0].delta.content:
                 collected.append(chunk.choices[0].delta.content)
         assert "".join(collected)
+
+
+@pytest.mark.integration
+class TestLowLevelEHBPIntegration:
+    """The low-level SecureClient.get()/post() path against a live enclave.
+
+    Covers both transport modes and, for EHBP, both request shapes: a bodyless
+    GET (which SPEC 7.4 sends without body encryption) and a POST whose body is
+    sealed end-to-end to the enclave's HPKE key.
+    """
+
+    REPO = "tinfoilsh/confidential-model-router"
+
+    def _client(self, transport: str) -> SecureClient:
+        try:
+            enclave = get_router_address()
+        except Exception as e:
+            pytest.skip(f"Could not fetch router address from ATC service: {e}")
+        return SecureClient(enclave=enclave, repo=self.REPO, transport=transport)
+
+    @pytest.mark.parametrize("transport", ["ehbp", "tls"])
+    def test_low_level_bodyless_get_models(self, transport):
+        api_key = _require_api_key()
+        client = self._client(transport)
+        resp = client.get(
+            f"https://{client.enclave}/v1/models",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        assert resp.status_code == 200, resp.body
+
+    @pytest.mark.parametrize("transport", ["ehbp", "tls"])
+    def test_low_level_post_chat(self, transport):
+        api_key = _require_api_key()
+        client = self._client(transport)
+        body = json.dumps(
+            {
+                "model": "llama3-3-70b",
+                "max_tokens": 5,
+                "messages": [
+                    {"role": "system", "content": "No matter what the user says, only respond with: Done."},
+                    {"role": "user", "content": "Is this a test?"},
+                ],
+            }
+        ).encode()
+        resp = client.post(
+            f"https://{client.enclave}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            body=body,
+        )
+        assert resp.status_code == 200, resp.body
+        assert json.loads(resp.body)["choices"]

--- a/tests/test_ehbp_transport.py
+++ b/tests/test_ehbp_transport.py
@@ -1,0 +1,244 @@
+"""
+Tests for the EHBP (Encrypted HTTP Body Protocol) transport mode.
+
+In EHBP mode request bodies are encrypted end-to-end to the enclave's attested
+HPKE public key, and the transport re-verifies attestation and retries once when
+the server rotates its HPKE key (surfaced as KeyConfigMismatchError).
+"""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+from ehbp import EHBPTransport, KeyConfigMismatchError
+
+from tinfoil import AsyncTinfoilAI, SecureClient, TinfoilAI
+from tinfoil.client import (
+    DEFAULT_TRANSPORT_MODE,
+    GroundTruth,
+    _AsyncEHBPReVerifyingTransport,
+    _EHBPReVerifyingTransport,
+    _ReVerifyingTransport,
+)
+
+
+def _valid_hpke_hex() -> str:
+    pk = X25519PrivateKey.generate().public_key()
+    return pk.public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw
+    ).hex()
+
+
+def _ground_truth(hpke: str) -> GroundTruth:
+    return GroundTruth(public_key="fp", digest="d", measurement="m", hpke_public_key=hpke)
+
+
+def _secure_client(transport: str = "ehbp") -> SecureClient:
+    # An explicit enclave avoids the router lookup (network) in __init__.
+    return SecureClient(enclave="enclave.test", repo="org/repo", transport=transport)
+
+
+class TestDefaultsAndValidation:
+    def test_default_transport_is_ehbp(self):
+        assert DEFAULT_TRANSPORT_MODE == "ehbp"
+        assert _secure_client().transport == "ehbp"
+
+    def test_ground_truth_has_hpke_field(self):
+        assert _ground_truth("abcd").hpke_public_key == "abcd"
+        assert GroundTruth("fp", "d", "m").hpke_public_key == ""
+
+    def test_invalid_transport_rejected(self):
+        with pytest.raises(ValueError):
+            SecureClient(enclave="enclave.test", repo="org/repo", transport="bogus")
+
+
+class TestRequireHPKEKey:
+    def test_returns_attested_key(self):
+        sc = _secure_client()
+        key = _valid_hpke_hex()
+        sc.verify = MagicMock(return_value=_ground_truth(key))
+        assert sc._require_hpke_public_key() == key
+
+    def test_raises_without_key(self):
+        sc = _secure_client()
+        sc.verify = MagicMock(return_value=_ground_truth(""))
+        with pytest.raises(ValueError):
+            sc._require_hpke_public_key()
+
+
+class TestTransportSelection:
+    def test_ehbp_mode_builds_ehbp_transport(self):
+        sc = _secure_client("ehbp")
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        client = sc.make_secure_http_client()
+        try:
+            assert isinstance(client._transport, _EHBPReVerifyingTransport)
+        finally:
+            client.close()
+
+    def test_tls_mode_builds_pinned_transport(self):
+        sc = _secure_client("tls")
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        client = sc.make_secure_http_client()
+        try:
+            assert isinstance(client._transport, _ReVerifyingTransport)
+        finally:
+            client.close()
+
+    def test_async_ehbp_mode_builds_ehbp_transport(self):
+        sc = _secure_client("ehbp")
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        client = sc.make_secure_async_http_client()
+        try:
+            assert isinstance(client._transport, _AsyncEHBPReVerifyingTransport)
+        finally:
+            asyncio.run(client.aclose())
+
+    def test_build_ehbp_sync_transport_returns_ehbp(self):
+        sc = _secure_client("ehbp")
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        inner = sc._build_ehbp_sync_transport()
+        try:
+            assert isinstance(inner, EHBPTransport)
+        finally:
+            inner.close()
+
+
+class _RaiseKeyMismatch(httpx.BaseTransport):
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        request.read()  # EHBP consumes the body before reporting the mismatch
+        raise KeyConfigMismatchError("rotated")
+
+
+class _OK(httpx.BaseTransport):
+    def __init__(self) -> None:
+        self.calls = 0
+        self.seen_body = None
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.calls += 1
+        self.seen_body = request.read()
+        return httpx.Response(200, content=b"recovered")
+
+
+class _RaiseOther(httpx.BaseTransport):
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+
+class TestSyncReverify:
+    def test_retries_on_key_rotation_and_replays_body(self):
+        sc = _secure_client()
+        ok = _OK()
+        sc._build_ehbp_sync_transport = MagicMock(return_value=ok)
+
+        wrapper = _EHBPReVerifyingTransport(sc, _RaiseKeyMismatch())
+        request = httpx.Request("POST", "https://enclave.test/v1/chat/completions", content=b"payload")
+        resp = wrapper.handle_request(request)
+
+        assert resp.status_code == 200
+        assert resp.read() == b"recovered"
+        assert ok.calls == 1
+        assert ok.seen_body == b"payload"
+        assert sc._build_ehbp_sync_transport.call_count == 1
+
+    def test_passes_through_other_errors_without_reverify(self):
+        sc = _secure_client()
+        sc._build_ehbp_sync_transport = MagicMock()
+
+        wrapper = _EHBPReVerifyingTransport(sc, _RaiseOther())
+        request = httpx.Request("POST", "https://enclave.test/v1/chat/completions", content=b"payload")
+        with pytest.raises(httpx.ConnectError):
+            wrapper.handle_request(request)
+        sc._build_ehbp_sync_transport.assert_not_called()
+
+    def test_surfaces_original_error_when_reverify_fails(self):
+        sc = _secure_client()
+        sc._build_ehbp_sync_transport = MagicMock(side_effect=RuntimeError("attestation failed"))
+
+        wrapper = _EHBPReVerifyingTransport(sc, _RaiseKeyMismatch())
+        request = httpx.Request("POST", "https://enclave.test/v1/chat/completions", content=b"payload")
+        with pytest.raises(KeyConfigMismatchError):
+            wrapper.handle_request(request)
+
+
+class _AsyncRaiseKeyMismatch(httpx.AsyncBaseTransport):
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        await request.aread()
+        raise KeyConfigMismatchError("rotated")
+
+
+class _AsyncOK(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.calls = 0
+        self.seen_body = None
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.calls += 1
+        self.seen_body = await request.aread()
+        return httpx.Response(200, content=b"recovered")
+
+
+class TestAsyncReverify:
+    def test_retries_on_key_rotation_and_replays_body(self):
+        async def run():
+            sc = _secure_client()
+            ok = _AsyncOK()
+            sc._build_ehbp_async_transport = AsyncMock(return_value=ok)
+
+            wrapper = _AsyncEHBPReVerifyingTransport(sc, _AsyncRaiseKeyMismatch())
+            request = httpx.Request("POST", "https://enclave.test/v1/chat/completions", content=b"payload")
+            resp = await wrapper.handle_async_request(request)
+
+            assert resp.status_code == 200
+            assert await resp.aread() == b"recovered"
+            assert ok.calls == 1
+            assert ok.seen_body == b"payload"
+            assert sc._build_ehbp_async_transport.await_count == 1
+
+        asyncio.run(run())
+
+
+@pytest.mark.integration
+class TestIntegration:
+    @pytest.mark.parametrize("transport", ["ehbp", "tls"])
+    def test_chat_completion(self, transport):
+        api_key = os.getenv("TINFOIL_API_KEY")
+        if not api_key:
+            pytest.skip("TINFOIL_API_KEY not set")
+
+        client = TinfoilAI(api_key=api_key, transport=transport)
+        response = client.chat.completions.create(
+            model="llama3-3-70b",
+            messages=[
+                {"role": "system", "content": "No matter what the user says, only respond with: Done."},
+                {"role": "user", "content": "Is this a test?"},
+            ],
+        )
+        assert response.choices[0].message.content
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("transport", ["ehbp", "tls"])
+    async def test_async_streaming_chat_completion(self, transport):
+        api_key = os.getenv("TINFOIL_API_KEY")
+        if not api_key:
+            pytest.skip("TINFOIL_API_KEY not set")
+
+        client = AsyncTinfoilAI(api_key=api_key, transport=transport)
+        stream = await client.chat.completions.create(
+            model="llama3-3-70b",
+            messages=[
+                {"role": "system", "content": "No matter what the user says, only respond with: Done."},
+                {"role": "user", "content": "Is this a test?"},
+            ],
+            stream=True,
+        )
+        collected = []
+        async for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                collected.append(chunk.choices[0].delta.content)
+        assert "".join(collected)

--- a/tests/test_verification_failures.py
+++ b/tests/test_verification_failures.py
@@ -390,7 +390,7 @@ class TestAsyncTLSPinning:
 
     def _make_client_with_fake_verify(self):
         """Create a SecureClient that returns a fake fingerprint from verify()."""
-        client = SecureClient(enclave="test.enclave.sh", repo="test/repo")
+        client = SecureClient(enclave="test.enclave.sh", repo="test/repo", transport="tls")
         ground_truth = MagicMock()
         ground_truth.public_key = self.FAKE_FP
         client.verify = MagicMock(return_value=ground_truth)

--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,11 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-05-18T19:45:30.83521Z"
+exclude-newer = "2026-05-30T19:03:18.634819Z"
 exclude-newer-span = "P4D"
+
+[options.exclude-newer-package]
+tinfoil-ehbp = "2026-06-04T00:00:00Z"
 
 [manifest]
 constraints = [{ name = "idna", specifier = ">=3.15" }]
@@ -759,6 +762,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyhpke"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/37/1acb2cee5afd3dcf45b425b0d984a9cba8917fd935106ef278b42062ecfa/pyhpke-0.6.4.tar.gz", hash = "sha256:1402c6c41a0605941d2d2a589774d346c0e7a0dc7f745e84c6f0a06c2fd335c9", size = 1638147, upload-time = "2025-12-21T10:38:07.556Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/f6/ff7df9e21b38ec1c827efd90c28b3bc76eddbfdf5a44aaf2fadb59a17cb9/pyhpke-0.6.4-py3-none-any.whl", hash = "sha256:abd0b2fec1424858399ffbed0d236fb7e9740dece9907f59ca40bd567d7fef78", size = 23792, upload-time = "2025-12-21T10:38:06.172Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -961,6 +976,7 @@ dependencies = [
     { name = "pyopenssl" },
     { name = "requests" },
     { name = "sigstore" },
+    { name = "tinfoil-ehbp" },
     { name = "urllib3" },
 ]
 
@@ -980,6 +996,7 @@ requires-dist = [
     { name = "pyopenssl", specifier = ">=25.0.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "sigstore", specifier = ">=4.1.0" },
+    { name = "tinfoil-ehbp", specifier = ">=0.2.3" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
@@ -987,6 +1004,20 @@ requires-dist = [
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
+]
+
+[[package]]
+name = "tinfoil-ehbp"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "httpx" },
+    { name = "pyhpke" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/4a/59346272c0ccb7f2d086a44f8473ddef2e7d4980e66e6f1bffafef487a8f/tinfoil_ehbp-0.2.3.tar.gz", hash = "sha256:4f072aaaf68fa61cdfb102896aba6fd42a5f4fe5cbb78d09068f27fc527b5f91", size = 15273, upload-time = "2026-06-03T17:20:15.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/7d/dffe3d69e8f963ce8d51c2580618da333af15fc41d42f5caffe9bd1ee617/tinfoil_ehbp-0.2.3-py3-none-any.whl", hash = "sha256:7ab32844cfa8a82fe926b39d23cc6ecf5a93ab392d49ba279f8985aac79e2b87", size = 15093, upload-time = "2026-06-03T17:20:13.884Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an end-to-end encrypted EHBP (HPKE) transport and makes it the default. Low-level HTTP now honors the transport, stays bound to the attested enclave, and keeps the previous no-timeout behavior, with automatic re-attestation and a single retry on key rotation.

- New Features
  - Added `TransportMode` with default `DEFAULT_TRANSPORT_MODE = "ehbp"`; all clients (`TinfoilAI`, `AsyncTinfoilAI`, `NewSecureClient`, `SecureClient`) accept a `transport` parameter.
  - Implemented EHBP sync/async transports with transparent re-attestation and one retry on `KeyConfigMismatchError`.
  - Verification now surfaces the enclave’s HPKE public key; EHBP mode requires this key and errors if missing.
  - Low-level helpers now respect transport mode: `make_request()`/`post()` use a mode-aware `httpx` client, reject foreign hosts, and preserve an unbounded timeout; `get_http_client()` is only available with `transport="tls"`.
  - Added tests for EHBP, key rotation, low-level behavior, and integration for both `"ehbp"` and `"tls"` modes, including low-level EHBP GET/POST coverage. Introduced `tinfoil-ehbp>=0.2.3`.

- Migration
  - Default transport is now `"ehbp"`. To keep previous TLS pinning behavior, pass `transport="tls"` when constructing clients.
  - `NewSecureClient` now accepts `transport`.
  - If an enclave doesn’t expose an HPKE key, EHBP mode will error; use `transport="tls"` in that case.
  - `get_http_client()` only works with `transport="tls"`. For EHBP, use `make_secure_http_client()` or the high-level clients.

<sup>Written for commit d592eff173b4803fae1c87b44493e105d41e357d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-python/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

