### PR TITLE
Add encrypted proxy support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Notes
+
+## TLS pinning reviews
+
+- Treat TLS pinning as an HTTPS-only property. Plain `http://` requests are not attested TLS connections and should not be reported as certificate-pinning bypasses; only report them when a code path that promises HTTPS fails to reject plaintext.
+- A real TLS pinning bypass is an HTTPS request that can complete without the peer certificate public key matching the attested TLS public-key fingerprint.
+- Review proxy and redirect behavior carefully, but distinguish fail-closed behavior from bypasses.
+
+## EHBP bundle reviews
+
+- EHBP request-body security is bound to the attested HPKE key. The bundled enclave certificate carries domain, HPKE, and attestation-hash bindings; it is not expected to be chain-trusted or to prove the attested TLS public key in EHBP mode.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ sbom-files = ["sbom.cdx.json"]
 
 [project]
 name = "tinfoil"
-version = "0.12.2"
+version = "0.13.0"
 description = "Python client for Tinfoil"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tinfoil/__init__.py
+++ b/src/tinfoil/__init__.py
@@ -129,6 +129,7 @@ class _HTTPSecureClient:
         self.enclave = tf_client.enclave or enclave
 
     def get(self, url: str, headers: Optional[dict] = None, params: Optional[dict] = None, timeout: Optional[int] = None) -> httpx.Response:
+        self._tf_client.assert_request_allowed(url)
         return self._http_client.get(url, headers=headers, params=params, timeout=timeout)
 
     def post(
@@ -139,6 +140,7 @@ class _HTTPSecureClient:
         json: Optional[dict] = None,
         timeout: Optional[int] = None,
     ) -> httpx.Response:
+        self._tf_client.assert_request_allowed(url)
         return self._http_client.post(url, headers=headers, data=data, json=json, timeout=timeout)
 
 

--- a/src/tinfoil/__init__.py
+++ b/src/tinfoil/__init__.py
@@ -28,6 +28,8 @@ class TinfoilAI:
         measurement: Optional[dict] = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
         transport: TransportMode = DEFAULT_TRANSPORT_MODE,
+        base_url: str = "",
+        attestation_bundle_url: str = "",
     ):
         if measurement is not None:
             repo = ""
@@ -36,16 +38,20 @@ class TinfoilAI:
         if measurement is None and (repo == "" or repo is None):
             raise ValueError("Must provide either 'measurement' or 'repo' parameter for verification.")
         
-        # If enclave is empty, fetch a random one from the routers API
-        if enclave == "" or enclave is None:
+        # If enclave is empty, fetch a random one from the routers API. When
+        # attesting from a bundle, the enclave host comes from the verified
+        # bundle, so no router lookup is needed.
+        if (enclave == "" or enclave is None) and not attestation_bundle_url:
             enclave = get_router_address()
         
-        self.enclave = enclave
         self.api_key = api_key
-        self._secure_client = SecureClient(enclave, repo, measurement, transport=transport)
+        self._secure_client = SecureClient(enclave, repo, measurement, transport=transport, base_url=base_url, attestation_bundle_url=attestation_bundle_url)
         secure_http = self._secure_client.make_secure_http_client()
+        # Building the secure transport verifies attestation, so the enclave host
+        # is now known even when it came from a bundle.
+        self.enclave = self._secure_client.enclave
         self.client = OpenAI(
-            base_url=f"https://{enclave}/v1/",
+            base_url=base_url or f"https://{self.enclave}/v1/",
             api_key=api_key,
             timeout=timeout,
             http_client=secure_http,
@@ -76,6 +82,8 @@ class AsyncTinfoilAI:
         measurement: Optional[dict] = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
         transport: TransportMode = DEFAULT_TRANSPORT_MODE,
+        base_url: str = "",
+        attestation_bundle_url: str = "",
     ):
         if measurement is not None:
             repo = ""
@@ -84,17 +92,21 @@ class AsyncTinfoilAI:
         if measurement is None and (repo == "" or repo is None):
             raise ValueError("Must provide either 'measurement' or 'repo' parameter for verification.")
         
-        # If enclave is empty, fetch a random one from the routers API
-        if enclave == "" or enclave is None:
+        # If enclave is empty, fetch a random one from the routers API. When
+        # attesting from a bundle, the enclave host comes from the verified
+        # bundle, so no router lookup is needed.
+        if (enclave == "" or enclave is None) and not attestation_bundle_url:
             enclave = get_router_address()
         
-        self.enclave = enclave
         self.api_key = api_key
         # verifier client remains sync; only used to fetch the expected public key
-        self._secure_client = SecureClient(enclave, repo, measurement, transport=transport)
+        self._secure_client = SecureClient(enclave, repo, measurement, transport=transport, base_url=base_url, attestation_bundle_url=attestation_bundle_url)
         async_http = self._secure_client.make_secure_async_http_client()
+        # Building the secure transport verifies attestation, so the enclave host
+        # is now known even when it came from a bundle.
+        self.enclave = self._secure_client.enclave
         self.client = AsyncOpenAI(
-            base_url=f"https://{enclave}/v1/",
+            base_url=base_url or f"https://{self.enclave}/v1/",
             api_key=api_key,
             timeout=timeout,
             http_client=async_http,
@@ -110,9 +122,11 @@ class AsyncTinfoilAI:
 class _HTTPSecureClient:
     """Low-level HTTP client with enclave-pinned TLS."""
     def __init__(self, enclave: str, tf_client: SecureClient):
-        self.enclave = enclave
         self._tf_client = tf_client
         self._http_client = tf_client.make_secure_http_client()
+        # Building the transport verifies attestation; for a bundle the enclave
+        # host is only known afterwards.
+        self.enclave = tf_client.enclave or enclave
 
     def get(self, url: str, headers: Optional[dict] = None, params: Optional[dict] = None, timeout: Optional[int] = None) -> httpx.Response:
         return self._http_client.get(url, headers=headers, params=params, timeout=timeout)
@@ -128,7 +142,7 @@ class _HTTPSecureClient:
         return self._http_client.post(url, headers=headers, data=data, json=json, timeout=timeout)
 
 
-def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE):
+def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE, base_url: str = "", attestation_bundle_url: str = ""):
     """Create a secure HTTP client for direct GET/POST through the Tinfoil enclave."""
     if measurement is not None:
         repo = ""
@@ -137,11 +151,12 @@ def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model
     if measurement is None and (repo == "" or repo is None):
         raise ValueError("Must provide either 'measurement' or 'repo' parameter for verification.")
 
-    # If enclave is empty, fetch a random one from the routers API
-    if enclave == "" or enclave is None:
+    # If enclave is empty, fetch a random one from the routers API. When
+    # attesting from a bundle, the enclave host comes from the verified bundle.
+    if (enclave == "" or enclave is None) and not attestation_bundle_url:
         enclave = get_router_address()
 
-    tf_client = SecureClient(enclave, repo, measurement, transport=transport)
-    return _HTTPSecureClient(enclave, tf_client)
+    tf_client = SecureClient(enclave, repo, measurement, transport=transport, base_url=base_url, attestation_bundle_url=attestation_bundle_url)
+    return _HTTPSecureClient(tf_client.enclave, tf_client)
 
 __all__ = ["TinfoilAI", "AsyncTinfoilAI", "NewSecureClient", "SecureClient", "VerificationDocument", "TransportMode"]

--- a/src/tinfoil/attestation/__init__.py
+++ b/src/tinfoil/attestation/__init__.py
@@ -12,14 +12,20 @@ from .types import (
     RTMR3_ZERO,
 )
 from .attestation import (
+    Document,
     fetch_attestation,
     verify_attestation_json,
 )
 from .attestation_tdx import verify_tdx_attestation_v2, TdxAttestationError, verify_tdx_hardware
 from .attestation_sev import verify_sev_attestation_v2, SevAttestationError
+from .bundle import Bundle, fetch_bundle_from, verify_certificate
 
 __all__ = [
+    'Document',
     'fetch_attestation',
+    'fetch_bundle_from',
+    'verify_certificate',
+    'Bundle',
     'verify_sev_attestation_v2',
     'verify_tdx_attestation_v2',
     'verify_tdx_hardware',

--- a/src/tinfoil/attestation/attestation.py
+++ b/src/tinfoil/attestation/attestation.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import ssl
 from dataclasses import dataclass
+from typing import Optional
 
 import requests
 from cryptography import x509
@@ -28,16 +29,20 @@ class Document:
 
     def hash(self) -> str:
         """Returns the SHA-256 hash of the attestation document"""
-        all_data = str(self.format) + self.body
+        all_data = self.format.value + self.body
         return hashlib.sha256(all_data.encode()).hexdigest()
 
-    def verify(self) -> Verification:
+    def verify(self, vcek_der: Optional[bytes] = None) -> Verification:
         """
         Checks the attestation document against its trust root
-        and returns the inner measurements
+        and returns the inner measurements.
+
+        For SEV-SNP, vcek_der optionally supplies the VCEK certificate (for
+        example from an attestation bundle) instead of fetching it from the AMD
+        KDS proxy. It is ignored for TDX, which uses a different trust chain.
         """
         if self.format == PredicateType.SEV_GUEST_V2:
-            return verify_sev_attestation_v2(self.body)
+            return verify_sev_attestation_v2(self.body, vcek_der=vcek_der)
         elif self.format == PredicateType.TDX_GUEST_V2:
             return verify_tdx_attestation_v2(self.body)
         else:

--- a/src/tinfoil/attestation/attestation_sev.py
+++ b/src/tinfoil/attestation/attestation_sev.py
@@ -71,14 +71,20 @@ default_validation_options = ValidationOptions(
 # Main Entry Points
 # =============================================================================
 
-def verify_sev_attestation_v2(attestation_doc: str) -> Verification:
+def verify_sev_attestation_v2(attestation_doc: str, vcek_der: Optional[bytes] = None) -> Verification:
     """Verify SEV attestation document (v2 format) and return verification result.
+
+    Args:
+        attestation_doc: Base64-encoded attestation document
+        vcek_der: Optional DER-encoded VCEK certificate (for example from an
+            attestation bundle). When omitted, the VCEK is fetched from the AMD
+            KDS proxy. Either way it is validated against the AMD root chain.
 
     Raises:
         ValueError: If verification fails
     """
     try:
-        report = verify_sev_report(attestation_doc)
+        report = verify_sev_report(attestation_doc, vcek_der=vcek_der)
     except SevAttestationError as e:
         raise ValueError(f"SEV attestation verification failed: {e}") from e
 
@@ -110,6 +116,7 @@ def verify_sev_report(
     attestation_doc: str,
     is_compressed: bool = True,
     validation_options: Optional[ValidationOptions] = None,
+    vcek_der: Optional[bytes] = None,
 ) -> Report:
     """Verify SEV attestation document and return the parsed report.
 
@@ -117,6 +124,8 @@ def verify_sev_report(
         attestation_doc: Base64-encoded attestation document
         is_compressed: Whether the document is gzip-compressed (default True)
         validation_options: Custom validation options; uses module defaults if None
+        vcek_der: Optional DER-encoded VCEK certificate; when omitted it is
+            fetched from the AMD KDS proxy.
     """
     options = validation_options if validation_options is not None else default_validation_options
 
@@ -139,7 +148,7 @@ def verify_sev_report(
         raise SevAttestationError(f"Failed to parse report: {e}") from e
 
     try:
-        chain = CertificateChain.from_report(report)
+        chain = CertificateChain.from_report(report, vcek_der=vcek_der)
     except Exception as e:
         raise SevAttestationError(f"Failed to build certificate chain: {e}") from e
 

--- a/src/tinfoil/attestation/bundle.py
+++ b/src/tinfoil/attestation/bundle.py
@@ -1,0 +1,156 @@
+"""
+Attestation bundles for single-request verification.
+
+A bundle packages everything needed to verify an enclave (the enclave
+attestation report, the release digest, the Sigstore bundle, the AMD VCEK, and
+the enclave TLS certificate) so a client can attest by fetching a single
+document. This mirrors the bundle model used by the Go and JavaScript SDKs and
+lets attestation traffic flow through a proxy.
+"""
+
+import base64
+import json
+from dataclasses import dataclass
+
+import requests
+from cryptography import x509
+
+from .attestation import Document, REQUEST_TIMEOUT_SECONDS
+from .types import PredicateType
+
+ATTESTATION_BUNDLE_ENDPOINT = "/attestation"
+
+
+@dataclass
+class Bundle:
+    """A complete attestation bundle for single-request verification."""
+    domain: str
+    enclave_attestation_report: Document
+    digest: str
+    sigstore_bundle: bytes
+    vcek: str  # base64-encoded DER
+    enclave_cert: str  # PEM
+
+
+def fetch_bundle_from(attestation_bundle_url: str) -> Bundle:
+    """Fetches a complete attestation bundle from {url}/attestation."""
+    base = attestation_bundle_url.rstrip("/")
+    url = f"{base}{ATTESTATION_BUNDLE_ENDPOINT}"
+    response = requests.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+    response.raise_for_status()
+
+    try:
+        data = response.json()
+        report = data["enclaveAttestationReport"]
+        return Bundle(
+            domain=data["domain"],
+            enclave_attestation_report=Document(
+                format=PredicateType(report["format"]),
+                body=report["body"],
+            ),
+            digest=data["digest"],
+            sigstore_bundle=json.dumps(data["sigstoreBundle"]).encode(),
+            vcek=data.get("vcek", ""),
+            enclave_cert=data.get("enclaveCert", ""),
+        )
+    except (KeyError, TypeError, ValueError) as e:
+        raise ValueError(f"Invalid attestation bundle from {base}: {e}") from e
+
+
+def verify_certificate(
+    cert_pem: str,
+    expected_domain: str,
+    attestation_doc: Document,
+    expected_hpke_key: str,
+) -> str:
+    """
+    Verifies an enclave TLS certificate against expected values, binding it to
+    the verified attestation. Checks that the certificate is valid for the
+    expected domain, that its SANs encode the attested HPKE key, and that its
+    SANs encode the hash of the attestation document. Returns the HPKE public
+    key extracted from the certificate.
+    """
+    try:
+        cert = x509.load_pem_x509_certificate(cert_pem.encode())
+    except Exception as e:
+        raise ValueError(f"failed to parse certificate: {e}") from e
+
+    try:
+        san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+        sans = san.get_values_for_type(x509.DNSName)
+    except x509.ExtensionNotFound:
+        sans = []
+    if not sans:
+        raise ValueError("certificate has no Subject Alternative Names")
+
+    if not _matches_hostname(expected_domain, sans):
+        raise ValueError(f"certificate not valid for domain {expected_domain!r}; SANs: {sans}")
+
+    hpke_sans = [s for s in sans if ".hpke." in s]
+    if not hpke_sans:
+        raise ValueError("certificate SANs do not contain HPKE key")
+    hpke_public_key = _decode_domains(hpke_sans, "hpke").hex()
+    if hpke_public_key != expected_hpke_key:
+        raise ValueError(
+            f"HPKE key mismatch: certificate has {hpke_public_key}, expected {expected_hpke_key}"
+        )
+
+    hatt_sans = [s for s in sans if ".hatt." in s]
+    if not hatt_sans:
+        raise ValueError("certificate SANs do not contain attestation hash")
+    cert_attestation_hash = _decode_domains(hatt_sans, "hatt").decode()
+    computed_hash = attestation_doc.hash()
+    if cert_attestation_hash != computed_hash:
+        raise ValueError(
+            f"attestation hash mismatch: certificate has {cert_attestation_hash}, computed {computed_hash}"
+        )
+
+    return hpke_public_key
+
+
+def _matches_hostname(domain: str, sans: list) -> bool:
+    """Reports whether domain matches one of the DNS SANs (exact or wildcard)."""
+    domain = domain.lower()
+    for san in sans:
+        san = san.lower()
+        if san == domain:
+            return True
+        if san.startswith("*."):
+            suffix = san[1:]  # ".example.com"
+            if domain.endswith(suffix):
+                left = domain[: -len(suffix)]
+                if left and "." not in left:
+                    return True
+    return False
+
+
+def _decode_domains(domains: list, prefix: str) -> bytes:
+    """
+    Decodes dcode-encoded data spread across certificate SANs. Each SAN has the
+    form NN<base32-chunk>.<prefix>.<domain> where NN is the chunk index; chunks
+    are ordered by index, concatenated, and base32-decoded.
+    """
+    pattern = "." + prefix + "."
+    chunks = []
+    for d in domains:
+        if pattern not in d:
+            continue
+        first_part = d.split(".")[0]
+        if len(first_part) < 2:
+            continue
+        try:
+            idx = int(first_part[:2])
+        except ValueError:
+            continue
+        chunks.append((idx, first_part[2:]))
+
+    if not chunks:
+        raise ValueError(f"no domains with prefix: {prefix}")
+
+    chunks.sort(key=lambda c: c[0])
+    combined = "".join(chunk for _, chunk in chunks).upper()
+    padding = "=" * ((8 - len(combined) % 8) % 8)
+    try:
+        return base64.b32decode(combined + padding)
+    except Exception as e:
+        raise ValueError(f"base32 decode error: {e}") from e

--- a/src/tinfoil/attestation/bundle.py
+++ b/src/tinfoil/attestation/bundle.py
@@ -33,8 +33,15 @@ class Bundle:
     enclave_cert: str  # PEM
 
 
-def fetch_bundle_from(attestation_bundle_url: str) -> Bundle:
-    """Fetches a complete attestation bundle from {url}/attestation."""
+def fetch_bundle_from(
+    attestation_bundle_url: str, enclave: str = "", repo: str = ""
+) -> Bundle:
+    """Fetches a complete attestation bundle from {url}/attestation.
+
+    When an enclave host or a code repository is supplied, asks the bundle
+    service to assemble a bundle for that specific enclave/repo (via POST)
+    instead of returning the default router bundle (GET).
+    """
     # The bundle is the entire trust root; fetching it over plaintext would let
     # an attacker substitute it (MITM).
     if urlparse(attestation_bundle_url).scheme != "https":
@@ -43,7 +50,15 @@ def fetch_bundle_from(attestation_bundle_url: str) -> Bundle:
         )
     base = attestation_bundle_url.rstrip("/")
     url = f"{base}{ATTESTATION_BUNDLE_ENDPOINT}"
-    response = requests.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+    if enclave or repo:
+        body = {}
+        if enclave:
+            body["enclaveUrl"] = enclave if "://" in enclave else f"https://{enclave}"
+        if repo:
+            body["repo"] = repo
+        response = requests.post(url, json=body, timeout=REQUEST_TIMEOUT_SECONDS)
+    else:
+        response = requests.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
     response.raise_for_status()
 
     try:

--- a/src/tinfoil/attestation/bundle.py
+++ b/src/tinfoil/attestation/bundle.py
@@ -11,6 +11,7 @@ lets attestation traffic flow through a proxy.
 import base64
 import json
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 import requests
 from cryptography import x509
@@ -34,6 +35,12 @@ class Bundle:
 
 def fetch_bundle_from(attestation_bundle_url: str) -> Bundle:
     """Fetches a complete attestation bundle from {url}/attestation."""
+    # The bundle is the entire trust root; fetching it over plaintext would let
+    # an attacker substitute it (MITM).
+    if urlparse(attestation_bundle_url).scheme != "https":
+        raise ValueError(
+            f"attestation bundle URL must use https; got {attestation_bundle_url!r}"
+        )
     base = attestation_bundle_url.rstrip("/")
     url = f"{base}{ATTESTATION_BUNDLE_ENDPOINT}"
     response = requests.get(url, timeout=REQUEST_TIMEOUT_SECONDS)

--- a/src/tinfoil/attestation/bundle.py
+++ b/src/tinfoil/attestation/bundle.py
@@ -43,7 +43,9 @@ def fetch_bundle_from(
     instead of returning the default router bundle (GET).
     """
     # The bundle is the entire trust root; fetching it over plaintext would let
-    # an attacker substitute it (MITM).
+    # an attacker substitute it (MITM). Redirects are refused for the same
+    # reason: a redirect could send the fetch to a non-https or attacker-chosen
+    # target, bypassing the https-only check below.
     if urlparse(attestation_bundle_url).scheme != "https":
         raise ValueError(
             f"attestation bundle URL must use https; got {attestation_bundle_url!r}"
@@ -56,9 +58,13 @@ def fetch_bundle_from(
             body["enclaveUrl"] = enclave if "://" in enclave else f"https://{enclave}"
         if repo:
             body["repo"] = repo
-        response = requests.post(url, json=body, timeout=REQUEST_TIMEOUT_SECONDS)
+        response = requests.post(
+            url, json=body, timeout=REQUEST_TIMEOUT_SECONDS, allow_redirects=False
+        )
     else:
-        response = requests.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+        response = requests.get(
+            url, timeout=REQUEST_TIMEOUT_SECONDS, allow_redirects=False
+        )
     response.raise_for_status()
 
     try:
@@ -131,8 +137,12 @@ def verify_certificate(
 
 
 def _matches_hostname(domain: str, sans: list) -> bool:
-    """Reports whether domain matches one of the DNS SANs (exact or wildcard)."""
-    domain = domain.lower()
+    """Reports whether domain matches one of the DNS SANs (exact or wildcard).
+
+    Any port in domain is ignored: certificate SANs only ever carry hostnames,
+    so an enclave on a non-default port must still match its DNS SAN.
+    """
+    domain = (urlparse(f"//{domain}").hostname or domain).lower()
     for san in sans:
         san = san.lower()
         if san == domain:

--- a/src/tinfoil/attestation/verify_sev.py
+++ b/src/tinfoil/attestation/verify_sev.py
@@ -5,7 +5,7 @@ Simplified AMD SEV-SNP Attestation Verifier (VCEK Chain Only)
 
 import os
 from dataclasses import dataclass
-from typing import Dict, TypeAlias
+from typing import Dict, Optional, TypeAlias
 import binascii
 import requests
 from OpenSSL import crypto
@@ -87,7 +87,7 @@ class CertificateChain:
         return cls(ark=ark, ask=ask, vcek=vcek)
     
     @classmethod
-    def from_report(cls, report:Report) -> 'CertificateChain':
+    def from_report(cls, report:Report, vcek_der: Optional[bytes] = None) -> 'CertificateChain':
         productName: str = report.productName
 
         if productName != "Genoa":
@@ -102,31 +102,38 @@ class CertificateChain:
         if signer_info.signingKey != ReportSigner.VcekReportSigner:
             raise ValueError("This implementation only supports VCEK signed reports")
         
-        # Fetch (or load) the VCEK certificate
-        vcek_url = _VCEKCertURL(productName, report.chip_id, report.reported_tcb)
-        cache_path = cls._vcek_cache_path(productName, report.chip_id, report.reported_tcb)
-        
-        # 1. Try the on‑disk cache
-        if os.path.isfile(cache_path):
-            with open(cache_path, "rb") as fh:
-                vcek_cert_data = fh.read()
+        cache_path = None
+        if vcek_der is not None:
+            # VCEK supplied out-of-band (for example from an attestation bundle).
+            # It is still validated against the AMD ARK/ASK root chain in
+            # verify_chain(), so accepting it here does not weaken trust.
+            vcek_cert_data = vcek_der
         else:
-            # 2. Cache miss → fetch from the KDS endpoint
-            try:
-                response = requests.get(vcek_url, timeout=10)
-                response.raise_for_status()
-                vcek_cert_data = response.content
-                # Persist to cache so the next call is instant
-                _ensure_vcek_cache_dir()
+            # Fetch (or load) the VCEK certificate
+            vcek_url = _VCEKCertURL(productName, report.chip_id, report.reported_tcb)
+            cache_path = cls._vcek_cache_path(productName, report.chip_id, report.reported_tcb)
+
+            # 1. Try the on‑disk cache
+            if os.path.isfile(cache_path):
+                with open(cache_path, "rb") as fh:
+                    vcek_cert_data = fh.read()
+            else:
+                # 2. Cache miss → fetch from the KDS endpoint
                 try:
-                    tmp_path = cache_path + ".tmp"
-                    with open(tmp_path, "wb") as fh:
-                        fh.write(vcek_cert_data)
-                    os.replace(tmp_path, cache_path)
-                except OSError:
-                    pass
-            except requests.RequestException as e:
-                raise ValueError(f"Failed to fetch VCEK certificate: {e}") from e
+                    response = requests.get(vcek_url, timeout=10)
+                    response.raise_for_status()
+                    vcek_cert_data = response.content
+                    # Persist to cache so the next call is instant
+                    _ensure_vcek_cache_dir()
+                    try:
+                        tmp_path = cache_path + ".tmp"
+                        with open(tmp_path, "wb") as fh:
+                            fh.write(vcek_cert_data)
+                        os.replace(tmp_path, cache_path)
+                    except OSError:
+                        pass
+                except requests.RequestException as e:
+                    raise ValueError(f"Failed to fetch VCEK certificate: {e}") from e
 
         # Parse the (cached or freshly‑downloaded) certificate
         try:
@@ -141,7 +148,7 @@ class CertificateChain:
                 vcek = x509.load_der_x509_certificate(vcek_cert_data)
         except Exception as e:
             # Corrupted cache?  Remove and propagate error so caller can retry.
-            if os.path.exists(cache_path):
+            if cache_path and os.path.exists(cache_path):
                 try:
                     os.remove(cache_path)
                 except OSError:

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -38,6 +38,8 @@ from .sigstore import verify_attestation, fetch_latest_hardware_measurements
 # the request reaches the same enclave the client verified.
 ENCLAVE_URL_HEADER = "X-Tinfoil-Enclave-Url"
 
+DEFAULT_CONFIG_REPO = "tinfoilsh/confidential-model-router"
+
 
 _CERTIFICATE_VERIFY_ERROR_MARKERS = (
     "certificate_verify_failed",
@@ -449,7 +451,7 @@ class _AsyncEnclaveURLHeaderTransport(httpx.AsyncBaseTransport):
 class SecureClient:
     """A client that verifies and communicates with secure enclaves"""
     
-    def __init__(self, enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE, base_url: str = "", attestation_bundle_url: str = ""):
+    def __init__(self, enclave: str = "", repo: str = DEFAULT_CONFIG_REPO, measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE, base_url: str = "", attestation_bundle_url: str = ""):
         # Hardcoded measurement takes precedence over repo
         if measurement is not None:
             repo = ""
@@ -650,9 +652,13 @@ class SecureClient:
         Also populates the verification document with per-step status.
         """
         # When an attestation bundle URL is configured, attest from the bundle so
-        # the enclave does not need to be reached directly (proxy-friendly).
+        # the enclave does not need to be reached directly (proxy-friendly). Ask
+        # for an enclave/repo-specific bundle when either is set.
         if self.attestation_bundle_url:
-            return self.verify_from_bundle(fetch_bundle_from(self.attestation_bundle_url))
+            repo = self.repo if self.repo != DEFAULT_CONFIG_REPO else ""
+            return self.verify_from_bundle(
+                fetch_bundle_from(self.attestation_bundle_url, enclave=self.enclave, repo=repo)
+            )
 
         doc = VerificationDocument(
             config_repo=self.repo or "",

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -603,19 +603,23 @@ class SecureClient:
         rotates its key (for example after a server-side restart), the
         underlying transport automatically re-verifies attestation and retries
         the request once.
+
+        Redirects are not followed: a redirect target bypasses the enclave/proxy
+        host binding, so following one could leak plaintext headers (including
+        the API key) to an arbitrary host.
         """
         if self.transport == "ehbp":
             inner = self._build_ehbp_sync_transport()
             transport: httpx.BaseTransport = _EHBPReVerifyingTransport(self, inner)
             if self.base_url:
                 transport = _EnclaveURLHeaderTransport(transport, self)
-            return httpx.Client(transport=transport, follow_redirects=True)
+            return httpx.Client(transport=transport, follow_redirects=False)
 
         expected_fp = self.verify().public_key
         ctx = self._build_sync_ssl_context(expected_fp)
         inner = httpx.HTTPTransport(verify=ctx)
         transport = _ReVerifyingTransport(self, inner)
-        return httpx.Client(transport=transport, follow_redirects=True)
+        return httpx.Client(transport=transport, follow_redirects=False)
 
     def make_secure_async_http_client(self) -> httpx.AsyncClient:
         """
@@ -629,6 +633,10 @@ class SecureClient:
         rotates its key (for example after a server-side restart), the
         underlying transport automatically re-verifies attestation and retries
         the request once.
+
+        Redirects are not followed: a redirect target bypasses the enclave/proxy
+        host binding, so following one could leak plaintext headers (including
+        the API key) to an arbitrary host.
         """
         if self.transport == "ehbp":
             hpke_public_key = self._require_hpke_public_key()
@@ -636,13 +644,13 @@ class SecureClient:
             transport: httpx.AsyncBaseTransport = _AsyncEHBPReVerifyingTransport(self, inner)
             if self.base_url:
                 transport = _AsyncEnclaveURLHeaderTransport(transport, self)
-            return httpx.AsyncClient(transport=transport, follow_redirects=True)
+            return httpx.AsyncClient(transport=transport, follow_redirects=False)
 
         expected_fp = self.verify().public_key
         ctx = self._build_async_ssl_context(expected_fp)
         inner = httpx.AsyncHTTPTransport(verify=ctx)
         transport = _AsyncReVerifyingTransport(self, inner)
-        return httpx.AsyncClient(transport=transport, follow_redirects=True)
+        return httpx.AsyncClient(transport=transport, follow_redirects=False)
 
     def verify(self) -> GroundTruth:
         """
@@ -869,29 +877,30 @@ class SecureClient:
             self._low_level_http_client = self.make_secure_http_client()
         return self._low_level_http_client
 
-    def _allowed_request_hosts(self) -> set:
-        """Hosts a request may target: the attested enclave and, if set, the proxy."""
-        hosts = set()
-        enclave_host = urlparse(f"//{self.enclave}").hostname
-        if enclave_host:
-            hosts.add(enclave_host)
+    def _allowed_request_endpoints(self) -> set:
+        """(host, port) pairs a request may target: the attested enclave and, if set, the proxy."""
+        endpoints = set()
+        enclave = urlparse(f"//{self.enclave}")
+        if enclave.hostname:
+            endpoints.add((enclave.hostname, enclave.port or 443))
         if self.base_url:
-            proxy_host = urlparse(self.base_url).hostname
-            if proxy_host:
-                hosts.add(proxy_host)
-        return hosts
+            proxy = urlparse(self.base_url)
+            if proxy.hostname:
+                endpoints.add((proxy.hostname, proxy.port or 443))
+        return endpoints
 
     def assert_request_allowed(self, url: str) -> None:
         """
         Guards the low-level escape hatches. Neither EHBP nor TLS pinning
         encrypts request headers (which may carry the API key), so a request may
         only target the attested enclave or the configured proxy, and only over
-        https. Raises ValueError otherwise.
+        https. The port is part of the binding so headers cannot be diverted to a
+        different service listening on an allowed host. Raises ValueError otherwise.
         """
         parsed = urlparse(url)
         if parsed.scheme != "https":
             raise ValueError(f"refusing to send request over non-https URL {url!r}")
-        if parsed.hostname not in self._allowed_request_hosts():
+        if (parsed.hostname, parsed.port or 443) not in self._allowed_request_endpoints():
             raise ValueError(
                 f"refusing to send request to host {parsed.hostname!r}: this "
                 f"secure client is bound to enclave {self.enclave!r}"

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -453,6 +453,20 @@ class SecureClient:
         if transport not in ("ehbp", "tls"):
             raise ValueError(f"Unknown transport mode: {transport!r}. Use 'ehbp' or 'tls'.")
 
+        # A pinned measurement and an attestation bundle are mutually exclusive
+        # verification methods: the bundle carries its own Sigstore code
+        # measurement, so honoring a pinned measurement would be ambiguous.
+        if measurement is not None and attestation_bundle_url:
+            raise ValueError(
+                "Cannot combine 'measurement' with 'attestation_bundle_url'; "
+                "the bundle provides its own code measurement."
+            )
+
+        # EHBP and TLS pinning leave request headers (which may carry the API
+        # key) in plaintext, so a proxy base URL must be https.
+        if base_url and urlparse(base_url).scheme != "https":
+            raise ValueError(f"base_url must use https; got {base_url!r}")
+
         # If enclave is empty, fetch a random one from the routers API. When
         # attesting from a bundle, the enclave host comes from the verified
         # bundle, so no router lookup is needed.
@@ -752,6 +766,12 @@ class SecureClient:
         try:
             vcek_der = base64.b64decode(bundle.vcek) if bundle.vcek else None
             verification = bundle.enclave_attestation_report.verify(vcek_der=vcek_der)
+            # For TDX, also verify the firmware/early-boot hardware measurements
+            # (mrtd, rtmr0), matching the direct attestation path; the bundle's
+            # multi-platform code measurement does not cover them.
+            if verification.measurement.type in TDX_TYPES:
+                hw_measurements = fetch_latest_hardware_measurements()
+                doc.hardware_measurement = verify_tdx_hardware(hw_measurements, verification.measurement)
             doc.enclave_measurement = verification
             doc.tls_public_key = verification.public_key_fp
             doc.hpke_public_key = verification.hpke_public_key or ""

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import contextlib
 import http.client
 import json
@@ -21,11 +22,21 @@ from ehbp import (
     KeyConfigMismatchError,
 )
 
-from .attestation import fetch_attestation, TDX_TYPES
+from .attestation import (
+    Bundle,
+    fetch_attestation,
+    fetch_bundle_from,
+    verify_certificate,
+    TDX_TYPES,
+)
 from .attestation.attestation_tdx import verify_tdx_hardware
 from .attestation.types import Measurement, HardwareMeasurement, Verification
 from .github import fetch_latest_digest, fetch_attestation_bundle
 from .sigstore import verify_attestation, fetch_latest_hardware_measurements
+
+# Header that tells a proxy which enclave to forward an encrypted request to, so
+# the request reaches the same enclave the client verified.
+ENCLAVE_URL_HEADER = "X-Tinfoil-Enclave-Url"
 
 
 _CERTIFICATE_VERIFY_ERROR_MARKERS = (
@@ -375,10 +386,62 @@ class _AsyncEHBPReVerifyingTransport(httpx.AsyncBaseTransport):
         await self._inner.aclose()
 
 
+def _enclave_url_header(base_url: str, enclave: str) -> tuple[str, bool]:
+    """
+    Returns the X-Tinfoil-Enclave-Url header value and whether it should be
+    injected. The header is only needed when requests are routed through a proxy
+    whose origin differs from the verified enclave's.
+    """
+    if not base_url or not enclave:
+        return "", False
+    enclave_url = f"https://{enclave}"
+    proxy = urlparse(base_url)
+    if not proxy.netloc:
+        return "", False
+    enclave_parsed = urlparse(enclave_url)
+    if (proxy.scheme, proxy.netloc) == (enclave_parsed.scheme, enclave_parsed.netloc):
+        return "", False
+    return enclave_url, True
+
+
+class _EnclaveURLHeaderTransport(httpx.BaseTransport):
+    """
+    Injects the X-Tinfoil-Enclave-Url header before delegating to the wrapped
+    transport. EHBP leaves request headers in plaintext, so the header reaches
+    the proxy while the body stays sealed to the enclave's HPKE key.
+    """
+
+    def __init__(self, inner: httpx.BaseTransport, enclave_url: str):
+        self._inner = inner
+        self._enclave_url = enclave_url
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        request.headers[ENCLAVE_URL_HEADER] = self._enclave_url
+        return self._inner.handle_request(request)
+
+    def close(self) -> None:
+        self._inner.close()
+
+
+class _AsyncEnclaveURLHeaderTransport(httpx.AsyncBaseTransport):
+    """Async counterpart of _EnclaveURLHeaderTransport."""
+
+    def __init__(self, inner: httpx.AsyncBaseTransport, enclave_url: str):
+        self._inner = inner
+        self._enclave_url = enclave_url
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        request.headers[ENCLAVE_URL_HEADER] = self._enclave_url
+        return await self._inner.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
 class SecureClient:
     """A client that verifies and communicates with secure enclaves"""
     
-    def __init__(self, enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE):
+    def __init__(self, enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE, base_url: str = "", attestation_bundle_url: str = ""):
         # Hardcoded measurement takes precedence over repo
         if measurement is not None:
             repo = ""
@@ -390,14 +453,18 @@ class SecureClient:
         if transport not in ("ehbp", "tls"):
             raise ValueError(f"Unknown transport mode: {transport!r}. Use 'ehbp' or 'tls'.")
 
-        # If enclave is empty, fetch a random one from the routers API
-        if enclave == "" or enclave is None:
+        # If enclave is empty, fetch a random one from the routers API. When
+        # attesting from a bundle, the enclave host comes from the verified
+        # bundle, so no router lookup is needed.
+        if (enclave == "" or enclave is None) and not attestation_bundle_url:
             enclave = get_router_address()
 
-        self.enclave = enclave
+        self.enclave = enclave or ""
         self.repo = repo
         self.measurement = measurement
         self.transport = transport
+        self.base_url = base_url
+        self.attestation_bundle_url = attestation_bundle_url
         self._ground_truth: Optional[GroundTruth] = None
         self._verification_document: Optional[VerificationDocument] = None
         self._low_level_http_client: Optional[httpx.Client] = None
@@ -502,7 +569,10 @@ class SecureClient:
         """
         if self.transport == "ehbp":
             inner = self._build_ehbp_sync_transport()
-            transport = _EHBPReVerifyingTransport(self, inner)
+            transport: httpx.BaseTransport = _EHBPReVerifyingTransport(self, inner)
+            header_value, inject = _enclave_url_header(self.base_url, self.enclave)
+            if inject:
+                transport = _EnclaveURLHeaderTransport(transport, header_value)
             return httpx.Client(transport=transport, follow_redirects=True)
 
         expected_fp = self.verify().public_key
@@ -527,7 +597,10 @@ class SecureClient:
         if self.transport == "ehbp":
             hpke_public_key = self._require_hpke_public_key()
             inner = AsyncEHBPTransport.from_public_key_hex(hpke_public_key, inner=httpx.AsyncHTTPTransport())
-            transport = _AsyncEHBPReVerifyingTransport(self, inner)
+            transport: httpx.AsyncBaseTransport = _AsyncEHBPReVerifyingTransport(self, inner)
+            header_value, inject = _enclave_url_header(self.base_url, self.enclave)
+            if inject:
+                transport = _AsyncEnclaveURLHeaderTransport(transport, header_value)
             return httpx.AsyncClient(transport=transport, follow_redirects=True)
 
         expected_fp = self.verify().public_key
@@ -543,6 +616,11 @@ class SecureClient:
 
         Also populates the verification document with per-step status.
         """
+        # When an attestation bundle URL is configured, attest from the bundle so
+        # the enclave does not need to be reached directly (proxy-friendly).
+        if self.attestation_bundle_url:
+            return self.verify_from_bundle(fetch_bundle_from(self.attestation_bundle_url))
+
         doc = VerificationDocument(
             config_repo=self.repo or "",
             enclave_host=self.enclave,
@@ -642,6 +720,82 @@ class SecureClient:
             )
             return self._ground_truth
 
+    def verify_from_bundle(self, bundle: Bundle) -> GroundTruth:
+        """
+        Verifies a pre-fetched attestation bundle entirely client-side and
+        stores the ground truth. The bundle supplies the enclave attestation
+        report, release digest, Sigstore bundle, AMD VCEK, and enclave TLS
+        certificate, so verification needs no direct connection to the enclave.
+        """
+        doc = VerificationDocument(
+            config_repo=self.repo or "",
+            enclave_host=bundle.domain,
+            selected_router_endpoint=bundle.domain,
+        )
+        self._verification_document = doc
+
+        # Step 1: Verify code measurement from the bundled Sigstore bundle
+        try:
+            code_measurements = verify_attestation(bundle.sigstore_bundle, bundle.digest, self.repo)
+            doc.release_digest = bundle.digest
+            doc.code_measurement = code_measurements
+            doc.code_fingerprint = code_measurements.fingerprint()
+            doc.steps["fetch_digest"] = VerificationStepState(status="success")
+            doc.steps["verify_code"] = VerificationStepState(status="success")
+        except Exception as e:
+            doc.steps["fetch_digest"] = VerificationStepState(status="failed", error=str(e))
+            doc.steps["verify_code"] = VerificationStepState(status="failed", error=str(e))
+            _attach_verification_document(e, doc)
+            raise
+
+        # Step 2: Verify the enclave attestation report using the bundled VCEK
+        try:
+            vcek_der = base64.b64decode(bundle.vcek) if bundle.vcek else None
+            verification = bundle.enclave_attestation_report.verify(vcek_der=vcek_der)
+            doc.enclave_measurement = verification
+            doc.tls_public_key = verification.public_key_fp
+            doc.hpke_public_key = verification.hpke_public_key or ""
+            doc.enclave_fingerprint = verification.measurement.fingerprint()
+            doc.steps["verify_enclave"] = VerificationStepState(status="success")
+        except Exception as e:
+            doc.steps["verify_enclave"] = VerificationStepState(status="failed", error=str(e))
+            _attach_verification_document(e, doc)
+            raise
+
+        # Step 3: Compare code and enclave measurements
+        try:
+            code_measurements.assert_equal(verification.measurement)
+            doc.steps["compare_measurements"] = VerificationStepState(status="success")
+        except Exception as e:
+            doc.steps["compare_measurements"] = VerificationStepState(status="failed", error=str(e))
+            _attach_verification_document(e, doc)
+            raise
+
+        # Step 4: Bind the enclave certificate to the verified attestation
+        try:
+            if not bundle.enclave_cert:
+                raise ValueError("attestation bundle is missing the enclave certificate")
+            verify_certificate(
+                bundle.enclave_cert,
+                bundle.domain,
+                bundle.enclave_attestation_report,
+                verification.hpke_public_key or "",
+            )
+        except Exception as e:
+            _attach_verification_document(e, doc)
+            raise
+
+        # Attestation came from the bundle; adopt its domain as the enclave host.
+        self.enclave = bundle.domain
+        doc.security_verified = True
+        self._ground_truth = GroundTruth(
+            public_key=verification.public_key_fp,
+            digest=bundle.digest,
+            measurement=verification.measurement,
+            hpke_public_key=verification.hpke_public_key or "",
+        )
+        return self._ground_truth
+
     def get_http_client(self) -> urllib.request.OpenerDirector:
         """
         Returns a urllib opener that pins the enclave's TLS certificate.
@@ -678,13 +832,20 @@ class SecureClient:
         """
         url = req.full_url
         parsed = urlparse(url)
-        # If URL doesn't have a host, assume it's relative to the enclave
+        enclave_host = urlparse(f"//{self.enclave}").hostname
+        proxy_host = urlparse(self.base_url).hostname if self.base_url else None
+        # If URL doesn't have a host, assume it's relative to the proxy (when
+        # configured) or the enclave.
         if not parsed.netloc:
-            url = f"https://{self.enclave}{url}"
-        elif parsed.hostname != urlparse(f"//{self.enclave}").hostname:
+            if proxy_host:
+                proxy = urlparse(self.base_url)
+                url = f"{proxy.scheme}://{proxy.netloc}{url}"
+            else:
+                url = f"https://{self.enclave}{url}"
+        elif parsed.hostname not in (enclave_host, proxy_host):
             # EHBP encrypts only the body; headers (which may carry the API key)
             # reach the destination in plaintext, so never send them to a host
-            # other than the attested enclave this client is bound to.
+            # other than the attested enclave or the configured proxy.
             raise ValueError(
                 f"refusing to send request to host {parsed.hostname!r}: this "
                 f"secure client is bound to enclave {self.enclave!r}"

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -824,6 +824,34 @@ class SecureClient:
             self._low_level_http_client = self.make_secure_http_client()
         return self._low_level_http_client
 
+    def _allowed_request_hosts(self) -> set:
+        """Hosts a request may target: the attested enclave and, if set, the proxy."""
+        hosts = set()
+        enclave_host = urlparse(f"//{self.enclave}").hostname
+        if enclave_host:
+            hosts.add(enclave_host)
+        if self.base_url:
+            proxy_host = urlparse(self.base_url).hostname
+            if proxy_host:
+                hosts.add(proxy_host)
+        return hosts
+
+    def assert_request_allowed(self, url: str) -> None:
+        """
+        Guards the low-level escape hatches. Neither EHBP nor TLS pinning
+        encrypts request headers (which may carry the API key), so a request may
+        only target the attested enclave or the configured proxy, and only over
+        https. Raises ValueError otherwise.
+        """
+        parsed = urlparse(url)
+        if parsed.scheme != "https":
+            raise ValueError(f"refusing to send request over non-https URL {url!r}")
+        if parsed.hostname not in self._allowed_request_hosts():
+            raise ValueError(
+                f"refusing to send request to host {parsed.hostname!r}: this "
+                f"secure client is bound to enclave {self.enclave!r}"
+            )
+
     def make_request(self, req: urllib.request.Request) -> Response:
         """
         Makes an HTTP request using the secure client, honoring the configured
@@ -832,24 +860,15 @@ class SecureClient:
         """
         url = req.full_url
         parsed = urlparse(url)
-        enclave_host = urlparse(f"//{self.enclave}").hostname
-        proxy_host = urlparse(self.base_url).hostname if self.base_url else None
         # If URL doesn't have a host, assume it's relative to the proxy (when
         # configured) or the enclave.
         if not parsed.netloc:
-            if proxy_host:
+            if self.base_url:
                 proxy = urlparse(self.base_url)
                 url = f"{proxy.scheme}://{proxy.netloc}{url}"
             else:
                 url = f"https://{self.enclave}{url}"
-        elif parsed.hostname not in (enclave_host, proxy_host):
-            # EHBP encrypts only the body; headers (which may carry the API key)
-            # reach the destination in plaintext, so never send them to a host
-            # other than the attested enclave or the configured proxy.
-            raise ValueError(
-                f"refusing to send request to host {parsed.hostname!r}: this "
-                f"secure client is bound to enclave {self.enclave!r}"
-            )
+        self.assert_request_allowed(url)
 
         response = self._secure_http_client().request(
             req.get_method(),

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -409,14 +409,20 @@ class _EnclaveURLHeaderTransport(httpx.BaseTransport):
     Injects the X-Tinfoil-Enclave-Url header before delegating to the wrapped
     transport. EHBP leaves request headers in plaintext, so the header reaches
     the proxy while the body stays sealed to the enclave's HPKE key.
+
+    The header is recomputed for every request from the client's current
+    enclave, so it stays correct after a re-verification swaps in a different
+    enclave (for example when attesting from a bundle behind a proxy).
     """
 
-    def __init__(self, inner: httpx.BaseTransport, enclave_url: str):
+    def __init__(self, inner: httpx.BaseTransport, client: "SecureClient"):
         self._inner = inner
-        self._enclave_url = enclave_url
+        self._client = client
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
-        request.headers[ENCLAVE_URL_HEADER] = self._enclave_url
+        header_value, inject = _enclave_url_header(self._client.base_url, self._client.enclave)
+        if inject:
+            request.headers[ENCLAVE_URL_HEADER] = header_value
         return self._inner.handle_request(request)
 
     def close(self) -> None:
@@ -426,12 +432,14 @@ class _EnclaveURLHeaderTransport(httpx.BaseTransport):
 class _AsyncEnclaveURLHeaderTransport(httpx.AsyncBaseTransport):
     """Async counterpart of _EnclaveURLHeaderTransport."""
 
-    def __init__(self, inner: httpx.AsyncBaseTransport, enclave_url: str):
+    def __init__(self, inner: httpx.AsyncBaseTransport, client: "SecureClient"):
         self._inner = inner
-        self._enclave_url = enclave_url
+        self._client = client
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        request.headers[ENCLAVE_URL_HEADER] = self._enclave_url
+        header_value, inject = _enclave_url_header(self._client.base_url, self._client.enclave)
+        if inject:
+            request.headers[ENCLAVE_URL_HEADER] = header_value
         return await self._inner.handle_async_request(request)
 
     async def aclose(self) -> None:
@@ -466,6 +474,14 @@ class SecureClient:
         # key) in plaintext, so a proxy base URL must be https.
         if base_url and urlparse(base_url).scheme != "https":
             raise ValueError(f"base_url must use https; got {base_url!r}")
+
+        # The attestation bundle is the entire trust root for verification.
+        # Fetching it over plaintext would let an attacker substitute the bundle
+        # (MITM), so the bundle URL must be https.
+        if attestation_bundle_url and urlparse(attestation_bundle_url).scheme != "https":
+            raise ValueError(
+                f"attestation_bundle_url must use https; got {attestation_bundle_url!r}"
+            )
 
         # Routing through a proxy base URL relies on EHBP sealing the body to the
         # enclave; TLS certificate pinning would reject the proxy's certificate.
@@ -589,9 +605,8 @@ class SecureClient:
         if self.transport == "ehbp":
             inner = self._build_ehbp_sync_transport()
             transport: httpx.BaseTransport = _EHBPReVerifyingTransport(self, inner)
-            header_value, inject = _enclave_url_header(self.base_url, self.enclave)
-            if inject:
-                transport = _EnclaveURLHeaderTransport(transport, header_value)
+            if self.base_url:
+                transport = _EnclaveURLHeaderTransport(transport, self)
             return httpx.Client(transport=transport, follow_redirects=True)
 
         expected_fp = self.verify().public_key
@@ -617,9 +632,8 @@ class SecureClient:
             hpke_public_key = self._require_hpke_public_key()
             inner = AsyncEHBPTransport.from_public_key_hex(hpke_public_key, inner=httpx.AsyncHTTPTransport())
             transport: httpx.AsyncBaseTransport = _AsyncEHBPReVerifyingTransport(self, inner)
-            header_value, inject = _enclave_url_header(self.base_url, self.enclave)
-            if inject:
-                transport = _AsyncEnclaveURLHeaderTransport(transport, header_value)
+            if self.base_url:
+                transport = _AsyncEnclaveURLHeaderTransport(transport, self)
             return httpx.AsyncClient(transport=transport, follow_redirects=True)
 
         expected_fp = self.verify().public_key
@@ -883,6 +897,11 @@ class SecureClient:
         transport mode: in "ehbp" mode the request body is encrypted end-to-end
         to the enclave, and in "tls" mode the enclave's certificate is pinned.
         """
+        # Build the client first so attestation runs and populates self.enclave.
+        # When attesting from a bundle the enclave host is only known after
+        # verification, so relative URLs must be resolved afterwards.
+        client = self._secure_http_client()
+
         url = req.full_url
         parsed = urlparse(url)
         # If URL doesn't have a host, assume it's relative to the proxy (when
@@ -895,7 +914,7 @@ class SecureClient:
                 url = f"https://{self.enclave}{url}"
         self.assert_request_allowed(url)
 
-        response = self._secure_http_client().request(
+        response = client.request(
             req.get_method(),
             url,
             headers=dict(req.header_items()),

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -467,6 +467,11 @@ class SecureClient:
         if base_url and urlparse(base_url).scheme != "https":
             raise ValueError(f"base_url must use https; got {base_url!r}")
 
+        # Routing through a proxy base URL relies on EHBP sealing the body to the
+        # enclave; TLS certificate pinning would reject the proxy's certificate.
+        if base_url and transport != "ehbp":
+            raise ValueError("base_url is only supported with the 'ehbp' transport")
+
         # If enclave is empty, fetch a random one from the routers API. When
         # attesting from a bundle, the enclave host comes from the verified
         # bundle, so no router lookup is needed.

--- a/tests/test_constructor_timeout.py
+++ b/tests/test_constructor_timeout.py
@@ -5,11 +5,13 @@ import tinfoil
 
 
 class FakeSecureClient:
-    def __init__(self, enclave, repo, measurement, transport="ehbp"):
+    def __init__(self, enclave, repo, measurement, transport="ehbp", base_url="", attestation_bundle_url=""):
         self.enclave = enclave
         self.repo = repo
         self.measurement = measurement
         self.transport = transport
+        self.base_url = base_url
+        self.attestation_bundle_url = attestation_bundle_url
 
     def make_secure_http_client(self):
         return "sync-http-client"

--- a/tests/test_ehbp_transport.py
+++ b/tests/test_ehbp_transport.py
@@ -110,6 +110,48 @@ class TestTransportSelection:
             inner.close()
 
 
+class TestRedirectsDisabled:
+    """The secure clients must not follow redirects: a redirect target is not
+    re-checked against the enclave/proxy host binding, so following one could
+    leak plaintext headers (including the API key) to an arbitrary host."""
+
+    def test_sync_ehbp_client_does_not_follow_redirects(self):
+        sc = _secure_client("ehbp")
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        client = sc.make_secure_http_client()
+        try:
+            assert client.follow_redirects is False
+        finally:
+            client.close()
+
+    def test_sync_tls_client_does_not_follow_redirects(self):
+        sc = _secure_client("tls")
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        client = sc.make_secure_http_client()
+        try:
+            assert client.follow_redirects is False
+        finally:
+            client.close()
+
+    def test_async_ehbp_client_does_not_follow_redirects(self):
+        sc = _secure_client("ehbp")
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        client = sc.make_secure_async_http_client()
+        try:
+            assert client.follow_redirects is False
+        finally:
+            asyncio.run(client.aclose())
+
+    def test_async_tls_client_does_not_follow_redirects(self):
+        sc = _secure_client("tls")
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        client = sc.make_secure_async_http_client()
+        try:
+            assert client.follow_redirects is False
+        finally:
+            asyncio.run(client.aclose())
+
+
 class TestLowLevelHonorsTransport:
     """The low-level get()/post() path must respect the configured transport."""
 

--- a/tests/test_encrypted_proxy.py
+++ b/tests/test_encrypted_proxy.py
@@ -19,6 +19,7 @@ import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 
+import tinfoil as tinfoil_module
 from tinfoil import AsyncTinfoilAI, SecureClient, TinfoilAI
 from tinfoil.attestation import Bundle, fetch_bundle_from
 from tinfoil.attestation.bundle import _decode_domains, _matches_hostname
@@ -161,6 +162,62 @@ class TestProxyHostBinding:
         with pytest.raises(ValueError, match="evil.example.com"):
             sc.get("https://evil.example.com/v1/models")
         http_client.request.assert_not_called()
+
+
+class TestAssertRequestAllowed:
+    """The low-level escape hatches must stay bound to the enclave/proxy host
+    and refuse plaintext (non-https) destinations."""
+
+    def _sc(self, base_url: str = ""):
+        return SecureClient(enclave="enclave.test", repo="org/repo", transport="ehbp", base_url=base_url)
+
+    def test_allows_enclave_https(self):
+        self._sc().assert_request_allowed("https://enclave.test/v1/models")
+
+    def test_allows_proxy_https(self):
+        self._sc("https://proxy.example.com/").assert_request_allowed("https://proxy.example.com/v1/models")
+
+    def test_rejects_foreign_host(self):
+        with pytest.raises(ValueError, match="evil.example.com"):
+            self._sc().assert_request_allowed("https://evil.example.com/v1/models")
+
+    def test_rejects_non_https(self):
+        with pytest.raises(ValueError, match="non-https"):
+            self._sc().assert_request_allowed("http://enclave.test/v1/models")
+
+
+class TestLowLevelHostBinding:
+    """NewSecureClient's get()/post() must enforce the host/scheme guard so an
+    API key in headers cannot be sent to a caller-supplied host."""
+
+    def _client(self, base_url: str = ""):
+        sc = SecureClient(enclave="enclave.test", repo="org/repo", transport="ehbp", base_url=base_url)
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        client = tinfoil_module._HTTPSecureClient("enclave.test", sc)
+        client._http_client = MagicMock()
+        client._http_client.get.return_value = "ok-get"
+        client._http_client.post.return_value = "ok-post"
+        return client
+
+    def test_get_rejects_foreign_host(self):
+        client = self._client()
+        with pytest.raises(ValueError, match="evil.example.com"):
+            client.get("https://evil.example.com/v1/models")
+        client._http_client.get.assert_not_called()
+
+    def test_post_rejects_non_https(self):
+        client = self._client()
+        with pytest.raises(ValueError, match="non-https"):
+            client.post("http://enclave.test/v1/chat/completions", json={})
+        client._http_client.post.assert_not_called()
+
+    def test_get_allows_enclave_host(self):
+        client = self._client()
+        assert client.get("https://enclave.test/v1/models") == "ok-get"
+
+    def test_get_allows_proxy_host(self):
+        client = self._client("https://proxy.example.com/")
+        assert client.get("https://proxy.example.com/v1/models") == "ok-get"
 
 
 class TestDecodeDomains:

--- a/tests/test_encrypted_proxy.py
+++ b/tests/test_encrypted_proxy.py
@@ -465,6 +465,59 @@ class TestFetchBundleParsing:
             with pytest.raises(ValueError, match="Invalid attestation bundle"):
                 fetch_bundle_from("https://atc.tinfoil.sh")
 
+    def test_rejects_non_https_url(self):
+        with pytest.raises(ValueError, match="https"):
+            fetch_bundle_from("http://atc.tinfoil.sh")
+
+
+class TestEnclaveSpecificBundle:
+    """fetch_bundle_from issues a POST so the bundle service assembles a bundle
+    for a specific enclave/repo, and a plain GET otherwise."""
+
+    _PAYLOAD = {
+        "domain": "inference.tinfoil.sh",
+        "enclaveAttestationReport": {
+            "format": "https://tinfoil.sh/predicate/sev-snp-guest/v2",
+            "body": "Zm9v",
+        },
+        "digest": "abc123",
+        "sigstoreBundle": {"mediaType": "application/vnd.dev.sigstore.bundle+json"},
+        "vcek": "AAECAw==",
+        "enclaveCert": "",
+    }
+
+    def _response(self):
+        response = MagicMock()
+        response.json.return_value = self._PAYLOAD
+        response.raise_for_status.return_value = None
+        return response
+
+    def test_get_when_no_enclave_or_repo(self):
+        with patch("tinfoil.attestation.bundle.requests.get", return_value=self._response()) as mock_get, \
+             patch("tinfoil.attestation.bundle.requests.post") as mock_post:
+            fetch_bundle_from("https://atc.tinfoil.sh")
+        mock_get.assert_called_once()
+        mock_post.assert_not_called()
+
+    def test_post_with_enclave_and_repo(self):
+        with patch("tinfoil.attestation.bundle.requests.post", return_value=self._response()) as mock_post, \
+             patch("tinfoil.attestation.bundle.requests.get") as mock_get:
+            fetch_bundle_from("https://atc.tinfoil.sh", enclave="enclave.test", repo="org/repo")
+        mock_get.assert_not_called()
+        mock_post.assert_called_once()
+        assert mock_post.call_args.args[0] == "https://atc.tinfoil.sh/attestation"
+        assert mock_post.call_args.kwargs["json"] == {
+            "enclaveUrl": "https://enclave.test",
+            "repo": "org/repo",
+        }
+
+    def test_post_with_only_enclave(self):
+        with patch("tinfoil.attestation.bundle.requests.post", return_value=self._response()) as mock_post, \
+             patch("tinfoil.attestation.bundle.requests.get") as mock_get:
+            fetch_bundle_from("https://atc.tinfoil.sh", enclave="enclave.test")
+        mock_get.assert_not_called()
+        assert mock_post.call_args.kwargs["json"] == {"enclaveUrl": "https://enclave.test"}
+
 
 def _require_api_key() -> str:
     api_key = os.getenv("TINFOIL_API_KEY")
@@ -490,6 +543,19 @@ class TestAttestationBundleIntegration:
         doc = sc.get_verification_document()
         assert doc is not None and doc.security_verified
         assert doc.enclave_host == sc.enclave
+
+    def test_verify_enclave_specific_bundle(self):
+        # Setting an explicit enclave makes the client POST to ATC for a bundle
+        # assembled for that enclave (rather than the default router bundle).
+        default = SecureClient(attestation_bundle_url=ATTESTATION_BUNDLE_URL)
+        default.verify()
+        enclave = default.enclave
+
+        sc = SecureClient(enclave=enclave, attestation_bundle_url=ATTESTATION_BUNDLE_URL)
+        ground_truth = sc.verify()
+        assert sc.enclave == enclave
+        assert ground_truth.hpke_public_key
+        assert sc.get_verification_document().security_verified
 
     def test_bundle_chat_completion(self):
         api_key = _require_api_key()

--- a/tests/test_encrypted_proxy.py
+++ b/tests/test_encrypted_proxy.py
@@ -228,6 +228,18 @@ class TestAssertRequestAllowed:
         with pytest.raises(ValueError, match="non-https"):
             self._sc().assert_request_allowed("http://enclave.test/v1/models")
 
+    def test_rejects_non_default_port_on_allowed_host(self):
+        with pytest.raises(ValueError, match="enclave.test"):
+            self._sc().assert_request_allowed("https://enclave.test:8443/v1/models")
+
+    def test_allows_explicit_default_port(self):
+        self._sc().assert_request_allowed("https://enclave.test:443/v1/models")
+
+    def test_rejects_non_default_port_on_proxy(self):
+        sc = self._sc("https://proxy.example.com/")
+        with pytest.raises(ValueError):
+            sc.assert_request_allowed("https://proxy.example.com:9000/v1/models")
+
 
 class TestLowLevelHostBinding:
     """NewSecureClient's get()/post() must enforce the host/scheme guard so an
@@ -309,6 +321,12 @@ class TestMatchesHostname:
 
     def test_no_match(self):
         assert _matches_hostname("evil.com", ["inference.tinfoil.sh"]) is False
+
+    def test_ignores_non_default_port(self):
+        assert _matches_hostname("inference.tinfoil.sh:8443", ["inference.tinfoil.sh"]) is True
+
+    def test_wildcard_match_ignores_port(self):
+        assert _matches_hostname("foo.tinfoil.sh:8443", ["*.tinfoil.sh"]) is True
 
 
 class TestConstructorValidation:
@@ -517,6 +535,18 @@ class TestEnclaveSpecificBundle:
             fetch_bundle_from("https://atc.tinfoil.sh", enclave="enclave.test")
         mock_get.assert_not_called()
         assert mock_post.call_args.kwargs["json"] == {"enclaveUrl": "https://enclave.test"}
+
+    def test_get_does_not_follow_redirects(self):
+        with patch("tinfoil.attestation.bundle.requests.get", return_value=self._response()) as mock_get, \
+             patch("tinfoil.attestation.bundle.requests.post"):
+            fetch_bundle_from("https://atc.tinfoil.sh")
+        assert mock_get.call_args.kwargs["allow_redirects"] is False
+
+    def test_post_does_not_follow_redirects(self):
+        with patch("tinfoil.attestation.bundle.requests.post", return_value=self._response()) as mock_post, \
+             patch("tinfoil.attestation.bundle.requests.get"):
+            fetch_bundle_from("https://atc.tinfoil.sh", enclave="enclave.test")
+        assert mock_post.call_args.kwargs["allow_redirects"] is False
 
 
 def _require_api_key() -> str:

--- a/tests/test_encrypted_proxy.py
+++ b/tests/test_encrypted_proxy.py
@@ -1,0 +1,303 @@
+"""
+Tests for encrypted-proxy support: routing EHBP requests (and attestation)
+through a proxy whose origin differs from the verified enclave's.
+
+When a proxy is configured the request body stays sealed to the enclave's HPKE
+key while the X-Tinfoil-Enclave-Url header tells the proxy which enclave to
+forward to. Attestation can likewise be performed from a bundle fetched through
+the proxy, so the enclave never needs to be reached directly to verify it.
+"""
+
+import asyncio
+import base64
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+
+from tinfoil import AsyncTinfoilAI, SecureClient, TinfoilAI
+from tinfoil.attestation import Bundle, fetch_bundle_from
+from tinfoil.attestation.bundle import _decode_domains, _matches_hostname
+from tinfoil.client import (
+    ENCLAVE_URL_HEADER,
+    GroundTruth,
+    _AsyncEnclaveURLHeaderTransport,
+    _EHBPReVerifyingTransport,
+    _EnclaveURLHeaderTransport,
+    _enclave_url_header,
+)
+
+
+def _valid_hpke_hex() -> str:
+    pk = X25519PrivateKey.generate().public_key()
+    return pk.public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw
+    ).hex()
+
+
+def _ground_truth(hpke: str) -> GroundTruth:
+    return GroundTruth(public_key="fp", digest="d", measurement="m", hpke_public_key=hpke)
+
+
+class TestEnclaveURLHeaderValue:
+    @pytest.mark.parametrize(
+        "base_url,enclave,want_val,want_ok",
+        [
+            ("https://proxy.example.com/", "enclave.example.com", "https://enclave.example.com", True),
+            ("https://proxy.example.com/api/v1/", "enclave.example.com", "https://enclave.example.com", True),
+            ("https://enclave.example.com/v1/", "enclave.example.com", "", False),
+            ("", "enclave.example.com", "", False),
+            ("https://proxy.example.com/", "", "", False),
+        ],
+    )
+    def test_header_value(self, base_url, enclave, want_val, want_ok):
+        val, ok = _enclave_url_header(base_url, enclave)
+        assert ok is want_ok
+        assert val == want_val
+
+
+class _RecordingTransport(httpx.BaseTransport):
+    def __init__(self) -> None:
+        self.seen_header = None
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.seen_header = request.headers.get(ENCLAVE_URL_HEADER)
+        return httpx.Response(200, content=b"ok")
+
+
+class _AsyncRecordingTransport(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.seen_header = None
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.seen_header = request.headers.get(ENCLAVE_URL_HEADER)
+        return httpx.Response(200, content=b"ok")
+
+
+class TestEnclaveURLHeaderTransport:
+    def test_sync_injects_header(self):
+        inner = _RecordingTransport()
+        transport = _EnclaveURLHeaderTransport(inner, "https://enclave.example.com")
+        request = httpx.Request("POST", "https://proxy.example.com/v1/chat/completions", content=b"payload")
+        resp = transport.handle_request(request)
+        assert resp.status_code == 200
+        assert inner.seen_header == "https://enclave.example.com"
+
+    def test_async_injects_header(self):
+        async def run():
+            inner = _AsyncRecordingTransport()
+            transport = _AsyncEnclaveURLHeaderTransport(inner, "https://enclave.example.com")
+            request = httpx.Request("POST", "https://proxy.example.com/v1/chat/completions", content=b"payload")
+            resp = await transport.handle_async_request(request)
+            assert resp.status_code == 200
+            assert inner.seen_header == "https://enclave.example.com"
+
+        asyncio.run(run())
+
+
+class TestProxyTransportWiring:
+    """make_secure_http_client wraps the EHBP transport with the header
+    transport only when routing through a proxy of a different origin."""
+
+    def _client(self, base_url: str):
+        sc = SecureClient(enclave="enclave.test", repo="org/repo", transport="ehbp", base_url=base_url)
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        return sc
+
+    def test_sync_wraps_when_proxying(self):
+        sc = self._client("https://proxy.example.com/")
+        client = sc.make_secure_http_client()
+        try:
+            assert isinstance(client._transport, _EnclaveURLHeaderTransport)
+            assert isinstance(client._transport._inner, _EHBPReVerifyingTransport)
+        finally:
+            client.close()
+
+    def test_sync_no_wrap_when_same_origin(self):
+        sc = self._client("https://enclave.test/v1/")
+        client = sc.make_secure_http_client()
+        try:
+            assert isinstance(client._transport, _EHBPReVerifyingTransport)
+        finally:
+            client.close()
+
+    def test_async_wraps_when_proxying(self):
+        sc = self._client("https://proxy.example.com/")
+        client = sc.make_secure_async_http_client()
+        try:
+            assert isinstance(client._transport, _AsyncEnclaveURLHeaderTransport)
+        finally:
+            asyncio.run(client.aclose())
+
+
+class TestProxyHostBinding:
+    """make_request must accept the configured proxy host in addition to the
+    enclave host, and still reject unrelated hosts (headers are plaintext)."""
+
+    def _client_with_mock(self, base_url: str = ""):
+        sc = SecureClient(enclave="enclave.test", repo="org/repo", transport="ehbp", base_url=base_url)
+        http_client = MagicMock()
+        http_client.request.return_value = httpx.Response(200, content=b"ok")
+        sc._low_level_http_client = http_client
+        return sc, http_client
+
+    def test_allows_proxy_host(self):
+        sc, http_client = self._client_with_mock("https://proxy.example.com/")
+        resp = sc.get("https://proxy.example.com/v1/models")
+        assert resp.status_code == 200
+        assert http_client.request.call_args.args[1] == "https://proxy.example.com/v1/models"
+
+    def test_still_allows_enclave_host(self):
+        sc, http_client = self._client_with_mock("https://proxy.example.com/")
+        resp = sc.get("https://enclave.test/v1/models")
+        assert resp.status_code == 200
+
+    def test_rejects_foreign_host_even_with_proxy(self):
+        sc, http_client = self._client_with_mock("https://proxy.example.com/")
+        with pytest.raises(ValueError, match="evil.example.com"):
+            sc.get("https://evil.example.com/v1/models")
+        http_client.request.assert_not_called()
+
+
+class TestDecodeDomains:
+    """_decode_domains reverses the dcode SAN encoding used by enclave certs."""
+
+    def test_round_trip_single_chunk(self):
+        data = b"hpke-public-key-bytes"
+        b32 = base64.b32encode(data).decode().rstrip("=")
+        sans = [f"00{b32}.hpke.enclave.example.com"]
+        assert _decode_domains(sans, "hpke") == data
+
+    def test_orders_chunks_by_index(self):
+        data = b"the quick brown fox jumps over the lazy dog!!"
+        b32 = base64.b32encode(data).decode().rstrip("=")
+        mid = len(b32) // 2
+        # Present the chunks out of order; decoding must reorder by index.
+        sans = [
+            f"01{b32[mid:]}.hatt.enclave.example.com",
+            f"00{b32[:mid]}.hatt.enclave.example.com",
+        ]
+        assert _decode_domains(sans, "hatt") == data
+
+    def test_ignores_other_prefixes(self):
+        data = b"key"
+        b32 = base64.b32encode(data).decode().rstrip("=")
+        sans = [f"00{b32}.hpke.enclave.example.com", "00ZZZZ.hatt.enclave.example.com"]
+        assert _decode_domains(sans, "hpke") == data
+
+    def test_raises_without_matching_prefix(self):
+        with pytest.raises(ValueError):
+            _decode_domains(["00ABCD.hatt.example.com"], "hpke")
+
+
+class TestMatchesHostname:
+    def test_exact_match(self):
+        assert _matches_hostname("inference.tinfoil.sh", ["inference.tinfoil.sh"]) is True
+
+    def test_case_insensitive(self):
+        assert _matches_hostname("Inference.Tinfoil.SH", ["inference.tinfoil.sh"]) is True
+
+    def test_wildcard_single_label(self):
+        assert _matches_hostname("foo.tinfoil.sh", ["*.tinfoil.sh"]) is True
+
+    def test_wildcard_does_not_span_labels(self):
+        assert _matches_hostname("foo.bar.tinfoil.sh", ["*.tinfoil.sh"]) is False
+
+    def test_no_match(self):
+        assert _matches_hostname("evil.com", ["inference.tinfoil.sh"]) is False
+
+
+class TestFetchBundleParsing:
+    def test_parses_bundle_fields(self):
+        payload = {
+            "domain": "inference.tinfoil.sh",
+            "enclaveAttestationReport": {
+                "format": "https://tinfoil.sh/predicate/sev-snp-guest/v2",
+                "body": "Zm9v",
+            },
+            "digest": "abc123",
+            "sigstoreBundle": {"mediaType": "application/vnd.dev.sigstore.bundle+json"},
+            "vcek": "AAECAw==",
+            "enclaveCert": "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n",
+        }
+        response = MagicMock()
+        response.json.return_value = payload
+        response.raise_for_status.return_value = None
+
+        with patch("tinfoil.attestation.bundle.requests.get", return_value=response) as mock_get:
+            bundle = fetch_bundle_from("https://atc.tinfoil.sh/")
+
+        mock_get.assert_called_once()
+        assert mock_get.call_args.args[0] == "https://atc.tinfoil.sh/attestation"
+        assert isinstance(bundle, Bundle)
+        assert bundle.domain == "inference.tinfoil.sh"
+        assert bundle.digest == "abc123"
+        assert bundle.vcek == "AAECAw=="
+        assert bundle.enclave_attestation_report.body == "Zm9v"
+        # The Sigstore bundle is re-serialized to bytes for downstream verification.
+        assert json.loads(bundle.sigstore_bundle) == payload["sigstoreBundle"]
+
+    def test_rejects_malformed_bundle(self):
+        response = MagicMock()
+        response.json.return_value = {"domain": "x"}  # missing required fields
+        response.raise_for_status.return_value = None
+        with patch("tinfoil.attestation.bundle.requests.get", return_value=response):
+            with pytest.raises(ValueError, match="Invalid attestation bundle"):
+                fetch_bundle_from("https://atc.tinfoil.sh")
+
+
+def _require_api_key() -> str:
+    api_key = os.getenv("TINFOIL_API_KEY")
+    if not api_key:
+        pytest.fail("TINFOIL_API_KEY must be set to run the integration tests")
+    return api_key
+
+
+ATTESTATION_BUNDLE_URL = "https://atc.tinfoil.sh"
+
+
+@pytest.mark.integration
+class TestAttestationBundleIntegration:
+    """Exercises the attestation-through-proxy path against the live ATC bundle
+    endpoint: the bundle is fetched and verified entirely client-side and the
+    enclave host is taken from the verified bundle."""
+
+    def test_verify_from_bundle_directly(self):
+        sc = SecureClient(repo="tinfoilsh/confidential-model-router", attestation_bundle_url=ATTESTATION_BUNDLE_URL)
+        ground_truth = sc.verify()
+        assert sc.enclave, "enclave host should come from the verified bundle"
+        assert ground_truth.hpke_public_key
+        doc = sc.get_verification_document()
+        assert doc is not None and doc.security_verified
+        assert doc.enclave_host == sc.enclave
+
+    def test_bundle_chat_completion(self):
+        api_key = _require_api_key()
+        client = TinfoilAI(api_key=api_key, attestation_bundle_url=ATTESTATION_BUNDLE_URL)
+        assert client.enclave, "enclave host should come from the verified bundle"
+        response = client.chat.completions.create(
+            model="llama3-3-70b",
+            messages=[
+                {"role": "system", "content": "No matter what the user says, only respond with: Done."},
+                {"role": "user", "content": "Is this a test?"},
+            ],
+        )
+        assert response.choices[0].message.content
+
+    @pytest.mark.asyncio
+    async def test_async_bundle_chat_completion(self):
+        api_key = _require_api_key()
+        client = AsyncTinfoilAI(api_key=api_key, attestation_bundle_url=ATTESTATION_BUNDLE_URL)
+        assert client.enclave, "enclave host should come from the verified bundle"
+        response = await client.chat.completions.create(
+            model="llama3-3-70b",
+            messages=[
+                {"role": "system", "content": "No matter what the user says, only respond with: Done."},
+                {"role": "user", "content": "Is this a test?"},
+            ],
+        )
+        assert response.choices[0].message.content

--- a/tests/test_encrypted_proxy.py
+++ b/tests/test_encrypted_proxy.py
@@ -12,6 +12,7 @@ import asyncio
 import base64
 import json
 import os
+import urllib.request
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -81,9 +82,13 @@ class _AsyncRecordingTransport(httpx.AsyncBaseTransport):
 
 
 class TestEnclaveURLHeaderTransport:
+    def _client(self, enclave: str, base_url: str):
+        return SecureClient(enclave=enclave, repo="org/repo", transport="ehbp", base_url=base_url)
+
     def test_sync_injects_header(self):
         inner = _RecordingTransport()
-        transport = _EnclaveURLHeaderTransport(inner, "https://enclave.example.com")
+        sc = self._client("enclave.example.com", "https://proxy.example.com/")
+        transport = _EnclaveURLHeaderTransport(inner, sc)
         request = httpx.Request("POST", "https://proxy.example.com/v1/chat/completions", content=b"payload")
         resp = transport.handle_request(request)
         assert resp.status_code == 200
@@ -92,13 +97,39 @@ class TestEnclaveURLHeaderTransport:
     def test_async_injects_header(self):
         async def run():
             inner = _AsyncRecordingTransport()
-            transport = _AsyncEnclaveURLHeaderTransport(inner, "https://enclave.example.com")
+            sc = self._client("enclave.example.com", "https://proxy.example.com/")
+            transport = _AsyncEnclaveURLHeaderTransport(inner, sc)
             request = httpx.Request("POST", "https://proxy.example.com/v1/chat/completions", content=b"payload")
             resp = await transport.handle_async_request(request)
             assert resp.status_code == 200
             assert inner.seen_header == "https://enclave.example.com"
 
         asyncio.run(run())
+
+    def test_no_header_when_same_origin(self):
+        inner = _RecordingTransport()
+        sc = self._client("enclave.test", "https://enclave.test/v1/")
+        transport = _EnclaveURLHeaderTransport(inner, sc)
+        transport.handle_request(
+            httpx.Request("POST", "https://enclave.test/v1/chat/completions", content=b"payload")
+        )
+        assert inner.seen_header is None
+
+    def test_reflects_enclave_change_after_reverification(self):
+        inner = _RecordingTransport()
+        sc = self._client("old.example.com", "https://proxy.example.com/")
+        transport = _EnclaveURLHeaderTransport(inner, sc)
+        transport.handle_request(
+            httpx.Request("POST", "https://proxy.example.com/v1/x", content=b"p")
+        )
+        assert inner.seen_header == "https://old.example.com"
+        # A re-verification (e.g. bundle mode behind a proxy) may swap in a
+        # different enclave; the header must follow the current enclave.
+        sc.enclave = "new.example.com"
+        transport.handle_request(
+            httpx.Request("POST", "https://proxy.example.com/v1/x", content=b"p")
+        )
+        assert inner.seen_header == "https://new.example.com"
 
 
 class TestProxyTransportWiring:
@@ -119,8 +150,19 @@ class TestProxyTransportWiring:
         finally:
             client.close()
 
-    def test_sync_no_wrap_when_same_origin(self):
+    def test_sync_wraps_even_when_same_origin(self):
+        # With base_url set the header transport is always installed; it decides
+        # per request whether to inject, since the enclave can change after a
+        # re-verification.
         sc = self._client("https://enclave.test/v1/")
+        client = sc.make_secure_http_client()
+        try:
+            assert isinstance(client._transport, _EnclaveURLHeaderTransport)
+        finally:
+            client.close()
+
+    def test_sync_no_wrap_without_base_url(self):
+        sc = self._client("")
         client = sc.make_secure_http_client()
         try:
             assert isinstance(client._transport, _EHBPReVerifyingTransport)
@@ -292,6 +334,48 @@ class TestConstructorValidation:
     def test_measurement_and_bundle_url_are_exclusive(self):
         with pytest.raises(ValueError, match="attestation_bundle_url"):
             SecureClient(measurement={"snp_measurement": "abc"}, attestation_bundle_url="https://atc.example")
+
+    def test_attestation_bundle_url_must_be_https(self):
+        with pytest.raises(ValueError, match="https"):
+            SecureClient(attestation_bundle_url="http://atc.example")
+
+    def test_https_attestation_bundle_url_is_accepted(self):
+        sc = SecureClient(attestation_bundle_url="https://atc.example")
+        assert sc.attestation_bundle_url == "https://atc.example"
+
+
+class TestBundleModeRequestRouting:
+    """In bundle mode the enclave host is only known after verification, so
+    make_request must build the client (and run verification) before binding the
+    request to the enclave host."""
+
+    def test_request_allowed_after_bundle_populates_enclave(self):
+        sc = SecureClient(attestation_bundle_url="https://atc.example")
+        assert sc.enclave == ""  # unknown until the bundle is verified
+
+        captured = {}
+        fake_client = MagicMock()
+
+        def fake_request(method, url, **kwargs):
+            captured["url"] = url
+            return httpx.Response(200, content=b"ok")
+
+        fake_client.request.side_effect = fake_request
+
+        def build_client():
+            # Building the secure client runs attestation, which in bundle mode
+            # is what populates self.enclave from the verified bundle.
+            sc.enclave = "enclave-from-bundle.test"
+            sc._low_level_http_client = fake_client
+            return fake_client
+
+        sc._secure_http_client = build_client
+
+        # Before the fix the host check ran while self.enclave was still empty,
+        # so even a request to the real enclave was rejected.
+        resp = sc.get("https://enclave-from-bundle.test/v1/models")
+        assert resp.status_code == 200
+        assert captured["url"] == "https://enclave-from-bundle.test/v1/models"
 
 
 class TestBundleVerifiesTdxHardware:

--- a/tests/test_encrypted_proxy.py
+++ b/tests/test_encrypted_proxy.py
@@ -280,6 +280,15 @@ class TestConstructorValidation:
         sc = SecureClient(enclave="enclave.test", repo="org/repo", base_url="https://proxy.example.com/")
         assert sc.base_url == "https://proxy.example.com/"
 
+    def test_base_url_requires_ehbp_transport(self):
+        with pytest.raises(ValueError, match="ehbp"):
+            SecureClient(
+                enclave="enclave.test",
+                repo="org/repo",
+                base_url="https://proxy.example.com/",
+                transport="tls",
+            )
+
     def test_measurement_and_bundle_url_are_exclusive(self):
         with pytest.raises(ValueError, match="attestation_bundle_url"):
             SecureClient(measurement={"snp_measurement": "abc"}, attestation_bundle_url="https://atc.example")

--- a/tests/test_encrypted_proxy.py
+++ b/tests/test_encrypted_proxy.py
@@ -21,8 +21,9 @@ from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 
 import tinfoil as tinfoil_module
 from tinfoil import AsyncTinfoilAI, SecureClient, TinfoilAI
-from tinfoil.attestation import Bundle, fetch_bundle_from
+from tinfoil.attestation import Bundle, Document, fetch_bundle_from
 from tinfoil.attestation.bundle import _decode_domains, _matches_hostname
+from tinfoil.attestation.types import Measurement, PredicateType, Verification
 from tinfoil.client import (
     ENCLAVE_URL_HEADER,
     GroundTruth,
@@ -266,6 +267,71 @@ class TestMatchesHostname:
 
     def test_no_match(self):
         assert _matches_hostname("evil.com", ["inference.tinfoil.sh"]) is False
+
+
+class TestConstructorValidation:
+    """The constructor rejects insecure or contradictory proxy configuration."""
+
+    def test_base_url_must_be_https(self):
+        with pytest.raises(ValueError, match="https"):
+            SecureClient(enclave="enclave.test", repo="org/repo", base_url="http://proxy.example.com/")
+
+    def test_https_base_url_is_accepted(self):
+        sc = SecureClient(enclave="enclave.test", repo="org/repo", base_url="https://proxy.example.com/")
+        assert sc.base_url == "https://proxy.example.com/"
+
+    def test_measurement_and_bundle_url_are_exclusive(self):
+        with pytest.raises(ValueError, match="attestation_bundle_url"):
+            SecureClient(measurement={"snp_measurement": "abc"}, attestation_bundle_url="https://atc.example")
+
+
+class TestBundleVerifiesTdxHardware:
+    """The bundle path must verify TDX hardware measurements (mrtd/rtmr0) just
+    like the direct attestation path; otherwise a TDX enclave on tampered
+    firmware would pass verification."""
+
+    def _tdx_bundle(self) -> tuple:
+        report = Document(format=PredicateType.TDX_GUEST_V2, body="Zm9v")
+        bundle = Bundle(
+            domain="enclave.test",
+            enclave_attestation_report=report,
+            digest="d",
+            sigstore_bundle=b"{}",
+            vcek="",
+            enclave_cert="cert",
+        )
+        measurement = Measurement(
+            type=PredicateType.TDX_GUEST_V2,
+            registers=["mrtd", "rtmr0", "rtmr1", "rtmr2", "rtmr3"],
+        )
+        verification = Verification(measurement=measurement, public_key_fp="fp", hpke_public_key="hpke")
+        return report, bundle, measurement, verification
+
+    def test_tdx_bundle_verifies_hardware_measurements(self):
+        report, bundle, measurement, verification = self._tdx_bundle()
+        sc = SecureClient(repo="org/repo", attestation_bundle_url="https://atc.example")
+
+        with patch.object(report, "verify", return_value=verification), \
+             patch("tinfoil.client.verify_attestation", return_value=MagicMock(spec=Measurement)), \
+             patch("tinfoil.client.fetch_latest_hardware_measurements", return_value="hw") as fetch_hw, \
+             patch("tinfoil.client.verify_tdx_hardware", return_value="hwm") as verify_hw, \
+             patch("tinfoil.client.verify_certificate", return_value="hpke"):
+            sc.verify_from_bundle(bundle)
+
+        fetch_hw.assert_called_once()
+        verify_hw.assert_called_once_with("hw", measurement)
+
+    def test_tdx_bundle_fails_when_hardware_mismatch(self):
+        report, bundle, _, verification = self._tdx_bundle()
+        sc = SecureClient(repo="org/repo", attestation_bundle_url="https://atc.example")
+
+        with patch.object(report, "verify", return_value=verification), \
+             patch("tinfoil.client.verify_attestation", return_value=MagicMock(spec=Measurement)), \
+             patch("tinfoil.client.fetch_latest_hardware_measurements", return_value="hw"), \
+             patch("tinfoil.client.verify_tdx_hardware", side_effect=ValueError("hardware mismatch")), \
+             patch("tinfoil.client.verify_certificate", return_value="hpke"):
+            with pytest.raises(ValueError, match="hardware mismatch"):
+                sc.verify_from_bundle(bundle)
 
 
 class TestFetchBundleParsing:

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-05-31T04:42:19.940911Z"
+exclude-newer = "2026-05-31T06:04:10.992747Z"
 exclude-newer-span = "P4D"
 
 [options.exclude-newer-package]
@@ -965,7 +965,7 @@ wheels = [
 
 [[package]]
 name = "tinfoil"
-version = "0.12.2"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds encrypted proxy support so EHBP requests and attestation can go through an HTTPS proxy while staying end-to-end encrypted to the enclave. Clients can verify from a single attestation bundle and automatically adopt the enclave host from the verified bundle.

- **New Features**
  - Encrypted proxy routing (sync/async) with `X-Tinfoil-Enclave-Url` auto-injected when `base_url` differs from the enclave.
  - Attestation bundles from `{attestation_bundle_url}/attestation` via GET or enclave/repo-specific POST; verify client-side including digest, Sigstore bundle, optional VCEK, and binding the enclave TLS cert by SAN-encoded HPKE key and attestation hash. The enclave host comes from the verified bundle; TDX also verifies firmware measurements.
  - New params: `base_url` and `attestation_bundle_url` on `TinfoilAI`, `AsyncTinfoilAI`, `SecureClient`, and `NewSecureClient`.

- **Bug Fixes**
  - Enforce https-only `base_url` and `attestation_bundle_url`; reject `base_url` with `transport="tls"`.
  - Disable redirects for secure clients and bundle fetches; bind low-level requests to https and only to the verified enclave or configured proxy (host and port).
  - Reject combining `measurement` with `attestation_bundle_url`; ensure bundle-mode requests bind after attestation.
  - Docs: clarify TLS pinning review scope and EHBP bundle expectations.

<sup>Written for commit 808acc570be3ad7523fe65ecf04d6ae84047e73a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-python/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

