### PR TITLE
sigstore: prefer canonical V2 OIDC issuer extension over deprecated V1

### DIFF
--- a/src/tinfoil/sigstore.py
+++ b/src/tinfoil/sigstore.py
@@ -1,5 +1,5 @@
-from sigstore.verify import Verifier 
-from sigstore.verify.policy import AllOf, OIDCIssuer, GitHubWorkflowRepository, Certificate, _OIDC_GITHUB_WORKFLOW_REF_OID, ExtensionNotFound
+from sigstore.verify import Verifier
+from sigstore.verify.policy import AllOf, OIDCIssuer, OIDCIssuerV2, GitHubWorkflowRepository, Certificate, _OIDC_GITHUB_WORKFLOW_REF_OID, _OIDC_ISSUER_V2_OID, ExtensionNotFound
 from sigstore.models import Bundle
 from sigstore.errors import VerificationError
 import json
@@ -10,6 +10,36 @@ from .attestation import Measurement, PredicateType, HardwareMeasurement
 from .github import fetch_latest_digest, fetch_attestation_bundle
 
 OIDC_ISSUER = "https://token.actions.githubusercontent.com"
+
+
+class OIDCIssuerV2Preferred:
+    """
+    Verifies the certificate's OIDC issuer, preferring the canonical V2
+    extension (1.3.6.1.4.1.57264.1.8) and falling back to the deprecated V1
+    extension (1.3.6.1.4.1.57264.1.1) only when V2 is absent.
+
+    Fulcio populates both extensions from the same OIDC token, but V1 is
+    officially deprecated in favor of V2. Verifying V1 while V2 is present
+    (sigstore-python's default `OIDCIssuer` only reads V1) would let a
+    certificate whose canonical V2 issuer is untrusted pass on a stale or
+    mismatched V1 value, and diverges from tinfoil-go / -rs / -js, which all
+    key on V2 with a V1 fallback. See SPEC §5.3.
+    """
+
+    def __init__(self, issuer: str) -> None:
+        self._v2 = OIDCIssuerV2(issuer)
+        self._v1 = OIDCIssuer(issuer)
+
+    def verify(self, cert: Certificate) -> None:
+        try:
+            cert.extensions.get_extension_for_oid(_OIDC_ISSUER_V2_OID)
+        except ExtensionNotFound:
+            # V2 absent: fall back to the deprecated V1 extension.
+            self._v1.verify(cert)
+            return
+        # V2 present: it is authoritative; the deprecated V1 is ignored.
+        self._v2.verify(cert)
+
 
 class GitHubWorkflowRefPattern:
     """
@@ -56,7 +86,7 @@ def _verify_dsse_bundle(bundle_json: bytes, digest: str, repo: str) -> dict:
     bundle = Bundle.from_json(bundle_json)
 
     policy = AllOf([
-        OIDCIssuer(OIDC_ISSUER),
+        OIDCIssuerV2Preferred(OIDC_ISSUER),
         GitHubWorkflowRepository(repo),
         GitHubWorkflowRefPattern("refs/tags/.*")
     ])


### PR DESCRIPTION
The certificate identity policy verified the OIDC issuer with sigstore-python's `OIDCIssuer`, which reads ONLY the deprecated V1 Fulcio extension (1.3.6.1.4.1.57264.1.1) and ignores the canonical V2 extension (1.3.6.1.4.1.57264.1.8). Fulcio populates both from the same OIDC token and has deprecated V1 in favor of V2.

When the two extensions disagree, reading V1 and ignoring V2 lets a certificate whose canonical (V2) issuer is untrusted pass on a stale or mismatched V1 value — a latent false-accept — and diverges from the other Tinfoil SDKs (go/rs/js), which all key on V2 with a V1 fallback.

Add `OIDCIssuerV2Preferred`: verify against V2 when the .1.8 extension is present (authoritative), otherwise fall back to the deprecated V1 .1.1 extension. This matches Fulcio guidance and homogenizes issuer verification across the SDKs. Behavior:
  - V1-only cert (canonical issuer)        -> accept (V1 fallback)
  - V1/V2 disagree, V2 = trusted issuer    -> accept (V2 authoritative)
  - V1/V2 disagree, V2 = untrusted issuer  -> reject (was: accepted)
  - neither extension present              -> reject

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer the canonical Fulcio OIDC issuer V2 extension (1.3.6.1.4.1.57264.1.8) over the deprecated V1 (1.3.6.1.4.1.57264.1.1) when verifying certificate identity, with a V1 fallback if V2 is missing. This closes a false-accept case when V1/V2 differ and aligns with other Tinfoil SDKs.

- **Bug Fixes**
  - Added `OIDCIssuerV2Preferred` that verifies V2 if present; falls back to V1 only when V2 is absent.
  - Updated DSSE bundle policy to use `OIDCIssuerV2Preferred` for the GitHub Actions issuer.

<sup>Written for commit 4648d2516cf33c963fd7fbc3e129ee0e28b5bceb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-python/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

