### PR TITLE
chore: bump version to 0.13.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ sbom-files = ["sbom.cdx.json"]
 
 [project]
 name = "tinfoil"
-version = "0.13.0"
+version = "0.13.1"
 description = "Python client for Tinfoil"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -966,7 +966,7 @@ wheels = [
 
 [[package]]
 name = "tinfoil"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `tinfoil` to 0.13.1 for a patch release. Updates version in `pyproject.toml` and syncs `uv.lock`.

<sup>Written for commit 5f6f8a50bac16cc312c4cc338a6f5fb2e9ac8475. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-python/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

