### PR TITLE
sigstore: reject in-toto statements with unknown top-level fields (SPEC §5.4)

### DIFF
--- a/src/tinfoil/sigstore.py
+++ b/src/tinfoil/sigstore.py
@@ -34,6 +34,24 @@ def reject_legacy_bundle_format(bundle_json: bytes) -> None:
         )
 
 
+_INTOTO_STATEMENT_FIELDS = frozenset({"_type", "subject", "predicateType", "predicate"})
+
+
+def reject_unknown_intoto_fields(statement: dict) -> None:
+    """SPEC §5.4: the in-toto statement MUST contain only the recognized
+    top-level fields (_type, subject, predicateType, predicate). Reject any
+    unknown top-level field, matching tinfoil-go (sigstore-go's strict protojson
+    parser rejects them). Tinfoil produces canonical statements, so an unknown
+    top-level field signals a non-canonical or malformed statement.
+    """
+    extra = set(statement) - _INTOTO_STATEMENT_FIELDS
+    if extra:
+        raise VerificationError(
+            "in-toto statement has unknown top-level field(s): "
+            + ", ".join(sorted(extra))
+        )
+
+
 def reject_duplicate_sct_logs(bundle: Bundle) -> None:
     """SPEC §5.2 anti-replay guard: reject a leaf certificate whose embedded
     SCT list contains two or more SCTs that share the same CT log ID, so a
@@ -152,6 +170,7 @@ def _verify_dsse_bundle(bundle_json: bytes, digest: str, repo: str) -> dict:
         raise ValueError(f"Unsupported payload type: {payload_type}")
 
     statement = json.loads(payload_bytes)
+    reject_unknown_intoto_fields(statement)
 
     subjects = statement.get("subject", [])
     if not subjects or "digest" not in subjects[0] or "sha256" not in subjects[0].get("digest", {}):


### PR DESCRIPTION
sigstore-python tolerates unknown top-level fields in the in-toto statement. Per SPEC §5.4 the statement MUST contain only the recognized fields (_type, subject, predicateType, predicate); reject_unknown_intoto_fields rejects any unknown top-level field after the statement is parsed. Tinfoil produces canonical statements, so an unknown field is non-canonical; this matches tinfoil-go/-rs/-js.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce SPEC §5.4 by rejecting in-toto statements that include unknown top-level fields during DSSE verification. Aligns validation with `tinfoil-go`/`tinfoil-rs`/`tinfoil-js` and prevents accepting non-canonical statements.

- **Bug Fixes**
  - Added `reject_unknown_intoto_fields` to allow only `_type`, `subject`, `predicateType`, `predicate`.
  - Called during `_verify_dsse_bundle`; raises `VerificationError` listing the extra fields.

<sup>Written for commit 78449e2e9479102e10982a3bf47bd73070262696. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-python/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

