### PR TITLE
feat: provision user_cache_secret for per-user prompt cache scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,36 @@ resp = tfclient.post(
 print(resp.status_code, resp.text)
 ```
 
+## Prompt Cache Scoping
+
+The inference router partitions its prompt cache per API identity, so your cached prompts are never observable by other tenants. Within your tenant, the SDK scopes caching further with a `user_cache_secret`: requests carrying the same secret share cached prompt prefixes, requests carrying different secrets cannot observe each other's cache timing. The secret never reaches the model — the router consumes it to derive the cache namespace and strips it from the request.
+
+By default the SDK generates a random secret and persists it at `~/.tinfoil/user_cache_secret` (mode `0600`, shared with the other Tinfoil SDKs on the same machine), so caching just works with per-machine scoping. You can control it explicitly:
+
+```python
+from tinfoil import TinfoilAI
+
+# Pin the secret for this client (e.g. one stable value per end user)
+client = TinfoilAI(api_key=api_key, user_cache_secret=secret)
+
+# Or provision it via the environment
+#   TINFOIL_USER_CACHE_SECRET=<secret>   use this value
+#   TINFOIL_USER_CACHE_SECRET=           (set but empty) disable: tenant-wide caching
+
+# Servers that hold many end users' conversations should scope per request;
+# a field set here always wins over the client-level secret:
+chat_completion = client.chat.completions.create(
+    model="llama3-3-70b",
+    messages=[{"role": "user", "content": "Hi"}],
+    extra_body={"user_cache_secret": per_user_secret},
+)
+
+# Opt out entirely (tenant-wide caching, no file written)
+client = TinfoilAI(api_key=api_key, user_cache_secret="")
+```
+
+`AsyncTinfoilAI` and `NewSecureClient` accept the same `user_cache_secret` parameter. If the secret cannot be persisted (no home directory, read-only filesystem), the SDK falls back to an in-memory secret and warns once: cache continuity then resets on every process restart. Containerized deployments should set `TINFOIL_USER_CACHE_SECRET` explicitly — one value per end user if requests are per-user, or empty to keep tenant-wide caching across replicas.
+
 ## Security
 
 Please report security vulnerabilities by emailing [security@tinfoil.sh](mailto:security@tinfoil.sh).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ sbom-files = ["sbom.cdx.json"]
 
 [project]
 name = "tinfoil"
-version = "0.13.3"
+version = "0.13.4"
 description = "Python client for Tinfoil"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tinfoil/__init__.py
+++ b/src/tinfoil/__init__.py
@@ -30,22 +30,23 @@ class TinfoilAI:
         transport: TransportMode = DEFAULT_TRANSPORT_MODE,
         base_url: Optional[str] = None,
         attestation_bundle_url: str = "",
+        user_cache_secret: Optional[str] = None,
     ):
         if measurement is not None:
             repo = ""
-        
+
         # Ensure at least one verification method is provided
         if measurement is None and (repo == "" or repo is None):
             raise ValueError("Must provide either 'measurement' or 'repo' parameter for verification.")
-        
+
         # If enclave is empty, fetch a random one from the routers API. When
         # attesting from a bundle, the enclave host comes from the verified
         # bundle, so no router lookup is needed.
         if (enclave == "" or enclave is None) and not attestation_bundle_url:
             enclave = get_router_address()
-        
+
         self.api_key = api_key
-        self._secure_client = SecureClient(enclave, repo, measurement, transport=transport, base_url=base_url, attestation_bundle_url=attestation_bundle_url)
+        self._secure_client = SecureClient(enclave, repo, measurement, transport=transport, base_url=base_url, attestation_bundle_url=attestation_bundle_url, user_cache_secret=user_cache_secret)
         secure_http = self._secure_client.make_secure_http_client()
         # Building the secure transport verifies attestation, so the enclave host
         # is now known even when it came from a bundle.
@@ -84,23 +85,24 @@ class AsyncTinfoilAI:
         transport: TransportMode = DEFAULT_TRANSPORT_MODE,
         base_url: Optional[str] = None,
         attestation_bundle_url: str = "",
+        user_cache_secret: Optional[str] = None,
     ):
         if measurement is not None:
             repo = ""
-        
+
         # Ensure at least one verification method is provided
         if measurement is None and (repo == "" or repo is None):
             raise ValueError("Must provide either 'measurement' or 'repo' parameter for verification.")
-        
+
         # If enclave is empty, fetch a random one from the routers API. When
         # attesting from a bundle, the enclave host comes from the verified
         # bundle, so no router lookup is needed.
         if (enclave == "" or enclave is None) and not attestation_bundle_url:
             enclave = get_router_address()
-        
+
         self.api_key = api_key
         # verifier client remains sync; only used to fetch the expected public key
-        self._secure_client = SecureClient(enclave, repo, measurement, transport=transport, base_url=base_url, attestation_bundle_url=attestation_bundle_url)
+        self._secure_client = SecureClient(enclave, repo, measurement, transport=transport, base_url=base_url, attestation_bundle_url=attestation_bundle_url, user_cache_secret=user_cache_secret)
         async_http = self._secure_client.make_secure_async_http_client()
         # Building the secure transport verifies attestation, so the enclave host
         # is now known even when it came from a bundle.
@@ -144,7 +146,7 @@ class _HTTPSecureClient:
         return self._http_client.post(url, headers=headers, data=data, json=json, timeout=timeout)
 
 
-def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE, base_url: Optional[str] = None, attestation_bundle_url: str = ""):
+def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE, base_url: Optional[str] = None, attestation_bundle_url: str = "", user_cache_secret: Optional[str] = None):
     """Create a secure HTTP client for direct GET/POST through the Tinfoil enclave."""
     if measurement is not None:
         repo = ""
@@ -158,7 +160,7 @@ def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model
     if (enclave == "" or enclave is None) and not attestation_bundle_url:
         enclave = get_router_address()
 
-    tf_client = SecureClient(enclave, repo, measurement, transport=transport, base_url=base_url, attestation_bundle_url=attestation_bundle_url)
+    tf_client = SecureClient(enclave, repo, measurement, transport=transport, base_url=base_url, attestation_bundle_url=attestation_bundle_url, user_cache_secret=user_cache_secret)
     return _HTTPSecureClient(tf_client.enclave, tf_client)
 
 __all__ = ["TinfoilAI", "AsyncTinfoilAI", "NewSecureClient", "SecureClient", "VerificationDocument", "TransportMode"]

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -33,6 +33,11 @@ from .attestation.attestation_tdx import verify_tdx_hardware
 from .attestation.types import Measurement, HardwareMeasurement, Verification
 from .github import fetch_latest_digest, fetch_attestation_bundle
 from .sigstore import verify_attestation, fetch_latest_hardware_measurements
+from .user_cache_secret import (
+    resolve_user_cache_secret,
+    _AsyncUserCacheSecretTransport,
+    _UserCacheSecretTransport,
+)
 
 # Header that tells a proxy which enclave to forward an encrypted request to, so
 # the request reaches the same enclave the client verified.
@@ -469,10 +474,40 @@ class _AsyncEnclaveURLHeaderTransport(httpx.AsyncBaseTransport):
         await self._inner.aclose()
 
 
+class _HostBoundTransport(httpx.BaseTransport):
+    """Rejects requests outside the verified enclave or configured proxy."""
+
+    def __init__(self, inner: httpx.BaseTransport, client: "SecureClient"):
+        self._inner = inner
+        self._client = client
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self._client.assert_request_allowed(str(request.url))
+        return self._inner.handle_request(request)
+
+    def close(self) -> None:
+        self._inner.close()
+
+
+class _AsyncHostBoundTransport(httpx.AsyncBaseTransport):
+    """Async counterpart of _HostBoundTransport."""
+
+    def __init__(self, inner: httpx.AsyncBaseTransport, client: "SecureClient"):
+        self._inner = inner
+        self._client = client
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self._client.assert_request_allowed(str(request.url))
+        return await self._inner.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
 class SecureClient:
     """A client that verifies and communicates with secure enclaves"""
     
-    def __init__(self, enclave: str = "", repo: str = DEFAULT_CONFIG_REPO, measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE, base_url: Optional[str] = None, attestation_bundle_url: str = ""):
+    def __init__(self, enclave: str = "", repo: str = DEFAULT_CONFIG_REPO, measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE, base_url: Optional[str] = None, attestation_bundle_url: str = "", user_cache_secret: Optional[str] = None):
         # Hardcoded measurement takes precedence over repo
         if measurement is not None:
             repo = ""
@@ -518,6 +553,12 @@ class SecureClient:
         self.transport = transport
         self.base_url = base_url or ""
         self.attestation_bundle_url = attestation_bundle_url
+        # The client-level prompt-cache secret, resolved once per client: the
+        # explicit parameter (None = unset; "" disables) beats the
+        # TINFOIL_USER_CACHE_SECRET environment variable, which beats the
+        # secret persisted at ~/.tinfoil/user_cache_secret. Empty means no
+        # injection: requests stay in the tenant-wide cache namespace.
+        self._user_cache_secret = resolve_user_cache_secret(user_cache_secret)
         self._ground_truth: Optional[GroundTruth] = None
         self._verification_document: Optional[VerificationDocument] = None
         self._low_level_http_client: Optional[httpx.Client] = None
@@ -621,6 +662,26 @@ class SecureClient:
         hpke_public_key = await asyncio.to_thread(self._require_hpke_public_key)
         return AsyncEHBPTransport.from_public_key_hex(hpke_public_key, inner=httpx.AsyncHTTPTransport())
 
+    def _wrap_sync_transport(
+        self, transport: httpx.BaseTransport
+    ) -> httpx.BaseTransport:
+        if self._user_cache_secret:
+            transport = _UserCacheSecretTransport(self._user_cache_secret, transport)
+        if self.transport == "ehbp" and self.base_url:
+            transport = _EnclaveURLHeaderTransport(transport, self)
+        return _HostBoundTransport(transport, self)
+
+    def _wrap_async_transport(
+        self, transport: httpx.AsyncBaseTransport
+    ) -> httpx.AsyncBaseTransport:
+        if self._user_cache_secret:
+            transport = _AsyncUserCacheSecretTransport(
+                self._user_cache_secret, transport
+            )
+        if self.transport == "ehbp" and self.base_url:
+            transport = _AsyncEnclaveURLHeaderTransport(transport, self)
+        return _AsyncHostBoundTransport(transport, self)
+
     def make_secure_http_client(self) -> httpx.Client:
         """
         Build an httpx.Client that securely communicates with the enclave.
@@ -634,15 +695,13 @@ class SecureClient:
         underlying transport automatically re-verifies attestation and retries
         the request once.
 
-        Redirects are not followed: a redirect target bypasses the enclave/proxy
-        host binding, so following one could disclose sensitive headers
-        (including the API key) to an arbitrary host.
+        Redirects are not followed, and every request is bound to the verified
+        enclave or configured proxy before any plaintext headers are sent.
         """
         if self.transport == "ehbp":
             inner = self._build_ehbp_sync_transport()
             transport: httpx.BaseTransport = _EHBPReVerifyingTransport(self, inner)
-            if self.base_url:
-                transport = _EnclaveURLHeaderTransport(transport, self)
+            transport = self._wrap_sync_transport(transport)
             return httpx.Client(transport=transport, follow_redirects=False)
 
         expected_fp = self.verify().public_key
@@ -650,6 +709,7 @@ class SecureClient:
         ctx = self._build_sync_ssl_context(expected_fp)
         inner = httpx.HTTPTransport(verify=ctx)
         transport = _ReVerifyingTransport(self, inner)
+        transport = self._wrap_sync_transport(transport)
         return httpx.Client(transport=transport, follow_redirects=False)
 
     def make_secure_async_http_client(self) -> httpx.AsyncClient:
@@ -665,16 +725,14 @@ class SecureClient:
         underlying transport automatically re-verifies attestation and retries
         the request once.
 
-        Redirects are not followed: a redirect target bypasses the enclave/proxy
-        host binding, so following one could disclose sensitive headers
-        (including the API key) to an arbitrary host.
+        Redirects are not followed, and every request is bound to the verified
+        enclave or configured proxy before any plaintext headers are sent.
         """
         if self.transport == "ehbp":
             hpke_public_key = self._require_hpke_public_key()
             inner = AsyncEHBPTransport.from_public_key_hex(hpke_public_key, inner=httpx.AsyncHTTPTransport())
             transport: httpx.AsyncBaseTransport = _AsyncEHBPReVerifyingTransport(self, inner)
-            if self.base_url:
-                transport = _AsyncEnclaveURLHeaderTransport(transport, self)
+            transport = self._wrap_async_transport(transport)
             return httpx.AsyncClient(transport=transport, follow_redirects=False)
 
         expected_fp = self.verify().public_key
@@ -682,6 +740,7 @@ class SecureClient:
         ctx = self._build_async_ssl_context(expected_fp)
         inner = httpx.AsyncHTTPTransport(verify=ctx)
         transport = _AsyncReVerifyingTransport(self, inner)
+        transport = self._wrap_async_transport(transport)
         return httpx.AsyncClient(transport=transport, follow_redirects=False)
 
     def verify(self) -> GroundTruth:

--- a/src/tinfoil/user_cache_secret.py
+++ b/src/tinfoil/user_cache_secret.py
@@ -1,0 +1,493 @@
+"""
+Provisions the per-user prompt-cache secret defined by the secure prompt
+caching contract. The router derives the request's prefix-cache namespace from
+the `user_cache_secret` body field: requests carrying the same secret (under
+the same API identity) share cached prompt prefixes, requests carrying
+different secrets cannot observe each other's cache timing. The secret itself
+is stripped by the router and never reaches the model.
+
+Resolution order, mirroring the other Tinfoil clients:
+
+1. an explicit per-request `user_cache_secret` field in the body (never
+   overwritten here),
+2. the `user_cache_secret` client parameter,
+3. the TINFOIL_USER_CACHE_SECRET environment variable,
+4. a generated secret persisted at ~/.tinfoil/user_cache_secret (0600), shared
+   with the other Tinfoil SDKs on the same machine.
+
+Injection happens in the transport, before the EHBP (or pinned-TLS) transport
+seals the body, so the secret is only ever visible to the verified enclave.
+"""
+
+import json
+import logging
+import os
+import secrets
+import stat
+import tempfile
+import threading
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger("tinfoil")
+
+# USER_CACHE_SECRET_FIELD is the router-only request-body field. A non-empty
+# string scopes the prompt cache to that secret; an absent or empty value
+# leaves the request in the tenant-wide namespace.
+USER_CACHE_SECRET_FIELD = "user_cache_secret"
+
+# USER_CACHE_SECRET_ENV provisions the secret via the environment. Setting it
+# to an empty string disables generation entirely (tenant-wide caching), which
+# is the right call for pooled multi-user deployments that would otherwise
+# mint a fresh namespace per container.
+USER_CACHE_SECRET_ENV = "TINFOIL_USER_CACHE_SECRET"
+
+# The persisted-secret path under the home directory. The other Tinfoil SDKs
+# use the same file, so one machine gets one cache namespace across tools.
+USER_CACHE_SECRET_DIR_NAME = ".tinfoil"
+USER_CACHE_SECRET_FILE_NAME = "user_cache_secret"
+_USER_CACHE_SECRET_DIR_MODE = 0o700
+
+# The OpenAI-compatible endpoints whose bodies carry the field. Matched by
+# suffix with no /v1 prefix required, so custom base URLs (path-prefixed
+# proxies or /v1-less roots) still qualify. Other endpoints (embeddings,
+# audio, files) are excluded: their engines do not prefix-cache and may
+# reject unknown fields.
+_USER_CACHE_SECRET_PATHS = (
+    "/chat/completions",
+    "/completions",
+    "/responses",
+)
+
+# JSON's whitespace set (RFC 8259): the only bytes allowed to trail the body's
+# top-level object. Python's str.strip() default would also accept characters
+# a strict JSON parser rejects.
+_JSON_WHITESPACE = " \t\n\r"
+
+# Unicode White_Space property, shared by the other SDK runtimes. Python's
+# str.strip() additionally removes U+001C through U+001F, which are secret data.
+_UNICODE_WHITESPACE = (
+    "\u0009\u000a\u000b\u000c\u000d\u0020\u0085\u00a0\u1680"
+    "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a"
+    "\u2028\u2029\u202f\u205f\u3000"
+)
+
+
+def resolve_user_cache_secret(explicit: Optional[str]) -> str:
+    """
+    Resolve the client-level secret: the explicit parameter wins (None means
+    unset; an empty string disables provisioning entirely), then the
+    environment, then the persisted (or generated) secret. An empty result
+    means injection is disabled and requests stay in the tenant-wide cache
+    namespace. Never raises: persistence and generation failures fall back as
+    documented on the helpers below.
+    """
+    if explicit is not None:
+        return explicit
+    env = os.environ.get(USER_CACHE_SECRET_ENV)
+    if env is not None:
+        return env
+    return _load_or_generate_user_cache_secret()
+
+
+def _new_user_cache_secret() -> str:
+    """Return a fresh 256-bit random secret, hex-encoded."""
+    try:
+        return secrets.token_hex(32)
+    except Exception as e:
+        # Never fall back to a weak secret: no secret means tenant-wide
+        # caching, which is safe.
+        logger.warning(
+            "tinfoil: could not generate a user cache secret; requests stay "
+            "in the tenant-wide cache namespace: %s",
+            e,
+        )
+        return ""
+
+
+# Process-lifetime fallback state for when the secret cannot be persisted; see
+# _ephemeral_user_cache_secret.
+_ephemeral_lock = threading.Lock()
+_ephemeral_secret: Optional[str] = None
+
+
+def _ephemeral_user_cache_secret() -> str:
+    """
+    The process-lifetime fallback for when the secret cannot be persisted. An
+    unpersisted secret still isolates this process's cache namespace, but
+    continuity is lost on restart — like a session ID, it silently resets the
+    namespace every deploy — so the fallback warns once per process.
+    """
+    global _ephemeral_secret
+    with _ephemeral_lock:
+        if _ephemeral_secret is None:
+            secret = _new_user_cache_secret()
+            if secret:
+                logger.warning(
+                    "tinfoil: could not persist the user cache secret; using "
+                    "an in-memory secret, so prompt-cache continuity resets "
+                    "when this process exits (set %s or the user_cache_secret "
+                    "parameter to pin one)",
+                    USER_CACHE_SECRET_ENV,
+                )
+            _ephemeral_secret = secret
+        return _ephemeral_secret
+
+
+def _user_cache_secret_path() -> Optional[Path]:
+    """
+    The persisted-secret path, or None when no home directory is available.
+    Matching the other Tinfoil clients (Go's os.UserHomeDir), only the home
+    environment variable is consulted — HOME, or USERPROFILE on Windows —
+    and unset or empty counts as no home; the OS account database is never
+    used, so scrubbed-environment daemons get the ephemeral fallback.
+    """
+    home = os.environ.get("USERPROFILE" if os.name == "nt" else "HOME")
+    if not home:
+        return None
+    return Path(home) / USER_CACHE_SECRET_DIR_NAME / USER_CACHE_SECRET_FILE_NAME
+
+
+def _load_or_generate_user_cache_secret() -> str:
+    """
+    Return the secret persisted under the user's home directory, generating
+    and persisting one on first use. When the home directory is unavailable or
+    unwritable it falls back to a process-lifetime in-memory secret.
+    """
+    path = _user_cache_secret_path()
+    if path is None:
+        return _ephemeral_user_cache_secret()
+
+    # ValueError alongside OSError throughout: pathological paths (e.g. an
+    # embedded null byte in $HOME) surface as ValueError, and resolution must
+    # never crash client construction.
+    try:
+        if os.name == "nt":
+            try:
+                parent_stat = os.lstat(path.parent)
+            except FileNotFoundError:
+                parent_stat = None
+            if parent_stat is not None and (
+                not stat.S_ISDIR(parent_stat.st_mode)
+                or _is_windows_reparse_point(parent_stat)
+            ):
+                return _ephemeral_user_cache_secret()
+        path.parent.mkdir(
+            mode=_USER_CACHE_SECRET_DIR_MODE, parents=True, exist_ok=True
+        )
+        if os.name == "nt":
+            parent_stat = os.lstat(path.parent)
+            if (
+                not stat.S_ISDIR(parent_stat.st_mode)
+                or _is_windows_reparse_point(parent_stat)
+            ):
+                return _ephemeral_user_cache_secret()
+        else:
+            directory_fd = _open_user_cache_secret_directory(path.parent)
+            os.close(directory_fd)
+    except (OSError, ValueError):
+        return _ephemeral_user_cache_secret()
+
+    existing, usable = _read_user_cache_secret(path)
+    if not usable:
+        return _ephemeral_user_cache_secret()
+    if existing is not None:
+        return existing
+
+    secret = _new_user_cache_secret()
+    if not secret:
+        return ""
+    return _persist_user_cache_secret(path, secret)
+
+
+def _read_user_cache_secret(path: Path) -> tuple[Optional[str], bool]:
+    """
+    Return (secret, usable), trimming surrounding whitespace. A missing file
+    is usable; a blank or invalid UTF-8 file is unusable and remains untouched.
+    """
+    fd, usable = _open_user_cache_secret(path)
+    if fd is None:
+        return None, usable
+    try:
+        with os.fdopen(fd, "rb") as secret_file:
+            fd = None
+            secret = secret_file.read().decode("utf-8").strip(_UNICODE_WHITESPACE)
+    except (OSError, UnicodeDecodeError, ValueError):
+        return None, False
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+    return (secret, True) if secret else (None, False)
+
+
+def _open_user_cache_secret(path: Path) -> tuple[Optional[int], bool]:
+    if os.name == "nt":
+        try:
+            path_stat = os.lstat(path)
+        except FileNotFoundError:
+            return None, True
+        except (OSError, ValueError):
+            return None, False
+        if (
+            not stat.S_ISREG(path_stat.st_mode)
+            or _is_windows_reparse_point(path_stat)
+        ):
+            return None, False
+
+    flags = os.O_RDONLY
+    if os.name != "nt":
+        no_follow = getattr(os, "O_NOFOLLOW", None)
+        if no_follow is None:
+            return None, False
+        flags |= (
+            no_follow
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+        )
+    try:
+        fd = os.open(path, flags)
+    except FileNotFoundError:
+        return None, True
+    except (OSError, ValueError):
+        return None, False
+
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            os.close(fd)
+            return None, False
+    except (OSError, ValueError):
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        return None, False
+    return fd, True
+
+
+def _is_windows_reparse_point(path_stat: os.stat_result) -> bool:
+    reparse_point = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    file_attributes = getattr(path_stat, "st_file_attributes", 0)
+    return bool(reparse_point and file_attributes & reparse_point)
+
+
+def _open_user_cache_secret_directory(path: Path) -> int:
+    directory = getattr(os, "O_DIRECTORY", None)
+    no_follow = getattr(os, "O_NOFOLLOW", None)
+    if directory is None or no_follow is None:
+        raise OSError("secure directory open flags are unavailable")
+    flags = os.O_RDONLY | directory | no_follow | getattr(os, "O_CLOEXEC", 0)
+    fd = os.open(path, flags)
+    try:
+        if not stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise OSError("cache secret parent is not a directory")
+    except (OSError, ValueError):
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        raise
+    return fd
+
+
+def _persist_user_cache_secret(path: Path, secret: str) -> str:
+    """Elect one complete secret across concurrent processes."""
+    candidate_path: Optional[Path] = None
+    candidate_fd: Optional[int] = None
+    try:
+        candidate_fd, candidate_name = tempfile.mkstemp(
+            prefix=f"{USER_CACHE_SECRET_FILE_NAME}.",
+            suffix=".tmp",
+            dir=path.parent,
+        )
+        candidate_path = Path(candidate_name)
+        try:
+            candidate = os.fdopen(candidate_fd, "w", encoding="utf-8")
+            candidate_fd = None
+            with candidate:
+                candidate.write(secret)
+        except (OSError, ValueError):
+            if candidate_fd is not None:
+                try:
+                    os.close(candidate_fd)
+                except (OSError, ValueError):
+                    pass
+            return _ephemeral_user_cache_secret()
+
+        try:
+            os.link(candidate_path, path)
+        except FileExistsError:
+            pass
+        except (OSError, ValueError):
+            return _ephemeral_user_cache_secret()
+
+        persisted, usable = _read_user_cache_secret(path)
+        if not usable or persisted is None:
+            return _ephemeral_user_cache_secret()
+        return persisted
+    except (OSError, ValueError):
+        return _ephemeral_user_cache_secret()
+    finally:
+        if candidate_fd is not None:
+            try:
+                os.close(candidate_fd)
+            except (OSError, ValueError):
+                pass
+        if candidate_path is not None:
+            try:
+                candidate_path.unlink(missing_ok=True)
+            except (OSError, ValueError):
+                pass
+
+
+class _UserCacheSecretTransport(httpx.BaseTransport):
+    """
+    Injects the client-level user_cache_secret into request bodies on the way
+    out. It sits above the sealing transport (EHBP or pinned TLS), so the
+    field is added before the body is sealed, and above the re-verifying retry
+    layer, so retries beneath it (EHBP key rotation) replay the injected body.
+    A field already present in the body is never overwritten — an explicit
+    per-request value, including an explicit empty string (= opt out for that
+    request), always wins.
+    """
+
+    def __init__(self, secret: str, inner: httpx.BaseTransport):
+        self._secret = secret
+        self._inner = inner
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        return self._inner.handle_request(
+            _request_with_user_cache_secret(request, self._secret)
+        )
+
+    def close(self) -> None:
+        self._inner.close()
+
+
+class _AsyncUserCacheSecretTransport(httpx.AsyncBaseTransport):
+    """Async counterpart to :class:`_UserCacheSecretTransport`."""
+
+    def __init__(self, secret: str, inner: httpx.AsyncBaseTransport):
+        self._secret = secret
+        self._inner = inner
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return await self._inner.handle_async_request(
+            await _async_request_with_user_cache_secret(request, self._secret)
+        )
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
+def _request_with_user_cache_secret(request: httpx.Request, secret: str) -> httpx.Request:
+    """
+    The request to forward: a copy whose body carries the injected field and
+    whose Content-Length describes the injected bytes, or the original request
+    untouched when injection does not apply (ineligible endpoint or method,
+    empty secret or body, or a body the injection must not rewrite — see
+    _body_with_user_cache_secret).
+    """
+    if not _request_eligible(request, secret):
+        return request
+    try:
+        raw = request.content
+    except httpx.RequestNotRead:
+        return request
+    return _request_with_user_cache_secret_body(request, secret, raw)
+
+
+async def _async_request_with_user_cache_secret(
+    request: httpx.Request, secret: str
+) -> httpx.Request:
+    """Async counterpart to :func:`_request_with_user_cache_secret`."""
+    if not _request_eligible(request, secret):
+        return request
+    try:
+        raw = request.content
+    except httpx.RequestNotRead:
+        return request
+    return _request_with_user_cache_secret_body(request, secret, raw)
+
+
+def _request_eligible(request: httpx.Request, secret: str) -> bool:
+    return (
+        bool(secret)
+        and request.method == "POST"
+        and _user_cache_secret_path_eligible(request.url.path)
+    )
+
+
+def _request_with_user_cache_secret_body(
+    request: httpx.Request, secret: str, raw: bytes
+) -> httpx.Request:
+    if not raw:
+        return request
+
+    body = _body_with_user_cache_secret(raw, secret)
+    if body is None:
+        return request
+
+    headers = request.headers.copy()
+    headers.pop("Transfer-Encoding", None)
+    headers["Content-Length"] = str(len(body))
+    return httpx.Request(
+        request.method,
+        request.url,
+        headers=headers,
+        content=body,
+        extensions=request.extensions,
+    )
+
+
+def _user_cache_secret_path_eligible(path: str) -> bool:
+    """Whether the URL path names an endpoint whose body carries the field."""
+    return path.endswith(_USER_CACHE_SECRET_PATHS)
+
+
+def _body_with_user_cache_secret(raw: bytes, secret: str) -> Optional[bytes]:
+    """
+    The body with the field spliced in before the object's closing brace, or
+    None — forward the original bytes — for non-object bodies, trailing data,
+    or a body that already carries the field. Splicing instead of
+    re-serializing keeps everything the caller sent byte-identical, including
+    number precision: int64-range values such as seed would be corrupted by a
+    float round-trip.
+    """
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+    start = len(text) - len(text.lstrip(_JSON_WHITESPACE))
+    try:
+        body, end = _STRICT_JSON_DECODER.raw_decode(text, start)
+    except (ValueError, RecursionError):
+        # RecursionError: CPython's json scanner recurses per nesting level
+        # and gives up on pathologically deep bodies (Go's decoder errors at
+        # its own depth limit) — forward them untouched like any other body
+        # this layer cannot parse, never raise out of the transport.
+        return None
+    # Trailing whitespace is legal JSON framing and must not block injection;
+    # anything else is trailing data the router-side parser would reject, so
+    # a request the server rejects must not quietly become one it accepts.
+    if not isinstance(body, dict) or text[end:].strip(_JSON_WHITESPACE):
+        return None
+    if USER_CACHE_SECRET_FIELD in body:
+        return None
+    field = f'"{USER_CACHE_SECRET_FIELD}":{json.dumps(secret)}'
+    comma = "," if body else ""
+    prefix, _, suffix = text.rpartition("}")
+    return f"{prefix}{comma}{field}}}{suffix}".encode()
+
+
+def _reject_json_constant(value: str) -> float:
+    # NaN/Infinity are accepted by Python's json module but are not JSON;
+    # treat them like any other malformed body and forward it untouched.
+    raise ValueError(f"non-standard JSON constant: {value}")
+
+
+_STRICT_JSON_DECODER = json.JSONDecoder(parse_constant=_reject_json_constant)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+from tinfoil.user_cache_secret import USER_CACHE_SECRET_ENV
+
+
+@pytest.fixture(autouse=True)
+def _pinned_user_cache_secret(monkeypatch):
+    """
+    Pin TINFOIL_USER_CACHE_SECRET for every test.
+
+    Constructing a client resolves the user cache secret; without the variable
+    the resolution would fall through to generating and persisting a secret in
+    the real ~/.tinfoil, making tests non-hermetic and the transport stack
+    shape environment-dependent. Tests that exercise resolution itself
+    override or remove the variable (and point HOME at a tmp dir) explicitly.
+    """
+    monkeypatch.setenv(USER_CACHE_SECRET_ENV, "test-secret")

--- a/tests/test_constructor_timeout.py
+++ b/tests/test_constructor_timeout.py
@@ -5,7 +5,7 @@ import tinfoil
 
 
 class FakeSecureClient:
-    def __init__(self, enclave, repo, measurement, transport="ehbp", base_url="", attestation_bundle_url=""):
+    def __init__(self, enclave, repo, measurement, transport="ehbp", base_url="", attestation_bundle_url="", user_cache_secret=None):
         self.enclave = enclave
         self.repo = repo
         self.measurement = measurement

--- a/tests/test_ehbp_transport.py
+++ b/tests/test_ehbp_transport.py
@@ -16,6 +16,7 @@ import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from ehbp import EHBPTransport, KeyConfigMismatchError
+from openai import APIConnectionError, OpenAI
 
 from tinfoil import AsyncTinfoilAI, SecureClient, TinfoilAI
 from tinfoil.client import (
@@ -23,8 +24,14 @@ from tinfoil.client import (
     GroundTruth,
     get_router_address,
     _AsyncEHBPReVerifyingTransport,
+    _AsyncHostBoundTransport,
     _EHBPReVerifyingTransport,
+    _HostBoundTransport,
     _ReVerifyingTransport,
+)
+from tinfoil.user_cache_secret import (
+    _AsyncUserCacheSecretTransport,
+    _UserCacheSecretTransport,
 )
 
 
@@ -73,12 +80,18 @@ class TestRequireHPKEKey:
 
 
 class TestTransportSelection:
+    # The user-cache-secret layer (the conftest fixture pins the secret)
+    # injects into the body before the sealing transport encrypts it.
     def test_ehbp_mode_builds_ehbp_transport(self):
         sc = _secure_client("ehbp")
         sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
         client = sc.make_secure_http_client()
         try:
-            assert isinstance(client._transport, _EHBPReVerifyingTransport)
+            bound = client._transport
+            assert isinstance(bound, _HostBoundTransport)
+            ucs = bound._inner
+            assert isinstance(ucs, _UserCacheSecretTransport)
+            assert isinstance(ucs._inner, _EHBPReVerifyingTransport)
         finally:
             client.close()
 
@@ -87,7 +100,11 @@ class TestTransportSelection:
         sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
         client = sc.make_secure_http_client()
         try:
-            assert isinstance(client._transport, _ReVerifyingTransport)
+            bound = client._transport
+            assert isinstance(bound, _HostBoundTransport)
+            ucs = bound._inner
+            assert isinstance(ucs, _UserCacheSecretTransport)
+            assert isinstance(ucs._inner, _ReVerifyingTransport)
         finally:
             client.close()
 
@@ -96,7 +113,11 @@ class TestTransportSelection:
         sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
         client = sc.make_secure_async_http_client()
         try:
-            assert isinstance(client._transport, _AsyncEHBPReVerifyingTransport)
+            bound = client._transport
+            assert isinstance(bound, _AsyncHostBoundTransport)
+            ucs = bound._inner
+            assert isinstance(ucs, _AsyncUserCacheSecretTransport)
+            assert isinstance(ucs._inner, _AsyncEHBPReVerifyingTransport)
         finally:
             asyncio.run(client.aclose())
 
@@ -111,10 +132,6 @@ class TestTransportSelection:
 
 
 class TestRedirectsDisabled:
-    """The secure clients must not follow redirects: a redirect target is not
-    re-checked against the enclave/proxy host binding, so following one could
-    disclose sensitive headers (including the API key) to an arbitrary host."""
-
     def test_sync_ehbp_client_does_not_follow_redirects(self):
         sc = _secure_client("ehbp")
         sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
@@ -160,7 +177,9 @@ class TestLowLevelHonorsTransport:
         sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
         client = sc._secure_http_client()
         try:
-            assert isinstance(client._transport, _EHBPReVerifyingTransport)
+            assert isinstance(client._transport, _HostBoundTransport)
+            assert isinstance(client._transport._inner, _UserCacheSecretTransport)
+            assert isinstance(client._transport._inner._inner, _EHBPReVerifyingTransport)
         finally:
             client.close()
 
@@ -169,7 +188,9 @@ class TestLowLevelHonorsTransport:
         sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
         client = sc._secure_http_client()
         try:
-            assert isinstance(client._transport, _ReVerifyingTransport)
+            assert isinstance(client._transport, _HostBoundTransport)
+            assert isinstance(client._transport._inner, _UserCacheSecretTransport)
+            assert isinstance(client._transport._inner._inner, _ReVerifyingTransport)
         finally:
             client.close()
 
@@ -183,6 +204,61 @@ class TestLowLevelHonorsTransport:
         sc = _secure_client("tls")
         sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
         assert sc.get_http_client() is not None
+
+
+class TestHTTPXClientHostBinding:
+    @pytest.mark.parametrize("transport", ["ehbp", "tls"])
+    def test_sync_client_rejects_foreign_origin(self, transport):
+        sc = _secure_client(transport)
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        client = sc.make_secure_http_client()
+        try:
+            with pytest.raises(ValueError, match="evil.example.com"):
+                client.get(
+                    "https://evil.example.com/v1/models",
+                    headers={"Authorization": "Bearer secret"},
+                )
+        finally:
+            client.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("transport", ["ehbp", "tls"])
+    async def test_async_client_rejects_foreign_origin(self, transport):
+        sc = _secure_client(transport)
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        client = sc.make_secure_async_http_client()
+        try:
+            with pytest.raises(ValueError, match="evil.example.com"):
+                await client.get(
+                    "https://evil.example.com/v1/models",
+                    headers={"Authorization": "Bearer secret"},
+                )
+        finally:
+            await client.aclose()
+
+    def test_openai_base_url_override_rejects_foreign_origin(self):
+        sc = _secure_client()
+        sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
+        http_client = sc.make_secure_http_client()
+        client = OpenAI(
+            api_key="secret",
+            base_url="https://enclave.test/v1",
+            http_client=http_client,
+            max_retries=0,
+        )
+        try:
+            foreign_client = client.with_options(
+                base_url="https://evil.example.com/v1"
+            )
+            with pytest.raises(APIConnectionError) as exc_info:
+                foreign_client.chat.completions.create(
+                    model="gpt-oss-120b",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+            assert isinstance(exc_info.value.__cause__, ValueError)
+            assert "evil.example.com" in str(exc_info.value.__cause__)
+        finally:
+            http_client.close()
 
 
 class TestMakeRequestHostBinding:
@@ -258,6 +334,25 @@ class TestSyncReverify:
         assert ok.seen_body == b"payload"
         assert sc._build_ehbp_sync_transport.call_count == 1
 
+    def test_retry_replays_injected_cache_secret(self):
+        sc = _secure_client()
+        ok = _OK()
+        sc._build_ehbp_sync_transport = MagicMock(return_value=ok)
+
+        transport = _UserCacheSecretTransport(
+            "cache-secret",
+            _EHBPReVerifyingTransport(sc, _RaiseKeyMismatch()),
+        )
+        request = httpx.Request(
+            "POST",
+            "https://enclave.test/v1/chat/completions",
+            content=b'{"model":"m"}',
+        )
+        response = transport.handle_request(request)
+
+        assert response.status_code == 200
+        assert json.loads(ok.seen_body)["user_cache_secret"] == "cache-secret"
+
     def test_passes_through_other_errors_without_reverify(self):
         sc = _secure_client()
         sc._build_ehbp_sync_transport = MagicMock()
@@ -311,6 +406,28 @@ class TestAsyncReverify:
             assert ok.calls == 1
             assert ok.seen_body == b"payload"
             assert sc._build_ehbp_async_transport.await_count == 1
+
+        asyncio.run(run())
+
+    def test_retry_replays_injected_cache_secret(self):
+        async def run():
+            sc = _secure_client()
+            ok = _AsyncOK()
+            sc._build_ehbp_async_transport = AsyncMock(return_value=ok)
+
+            transport = _AsyncUserCacheSecretTransport(
+                "cache-secret",
+                _AsyncEHBPReVerifyingTransport(sc, _AsyncRaiseKeyMismatch()),
+            )
+            request = httpx.Request(
+                "POST",
+                "https://enclave.test/v1/chat/completions",
+                content=b'{"model":"m"}',
+            )
+            response = await transport.handle_async_request(request)
+
+            assert response.status_code == 200
+            assert json.loads(ok.seen_body)["user_cache_secret"] == "cache-secret"
 
         asyncio.run(run())
 

--- a/tests/test_encrypted_proxy.py
+++ b/tests/test_encrypted_proxy.py
@@ -28,10 +28,17 @@ from tinfoil.attestation.types import Measurement, PredicateType, Verification
 from tinfoil.client import (
     ENCLAVE_URL_HEADER,
     GroundTruth,
+    _AsyncEHBPReVerifyingTransport,
     _AsyncEnclaveURLHeaderTransport,
+    _AsyncHostBoundTransport,
     _EHBPReVerifyingTransport,
     _EnclaveURLHeaderTransport,
+    _HostBoundTransport,
     _enclave_url_header,
+)
+from tinfoil.user_cache_secret import (
+    _AsyncUserCacheSecretTransport,
+    _UserCacheSecretTransport,
 )
 
 
@@ -145,8 +152,14 @@ class TestProxyTransportWiring:
         sc = self._client("http://proxy.example.com/")
         client = sc.make_secure_http_client()
         try:
-            assert isinstance(client._transport, _EnclaveURLHeaderTransport)
-            assert isinstance(client._transport._inner, _EHBPReVerifyingTransport)
+            # The user-cache-secret layer injects into the body before the
+            # EHBP re-verifying transport seals it.
+            assert isinstance(client._transport, _HostBoundTransport)
+            header = client._transport._inner
+            assert isinstance(header, _EnclaveURLHeaderTransport)
+            ucs = header._inner
+            assert isinstance(ucs, _UserCacheSecretTransport)
+            assert isinstance(ucs._inner, _EHBPReVerifyingTransport)
         finally:
             client.close()
 
@@ -157,7 +170,8 @@ class TestProxyTransportWiring:
         sc = self._client("https://enclave.test/v1/")
         client = sc.make_secure_http_client()
         try:
-            assert isinstance(client._transport, _EnclaveURLHeaderTransport)
+            assert isinstance(client._transport, _HostBoundTransport)
+            assert isinstance(client._transport._inner, _EnclaveURLHeaderTransport)
         finally:
             client.close()
 
@@ -165,7 +179,11 @@ class TestProxyTransportWiring:
         sc = self._client(None)
         client = sc.make_secure_http_client()
         try:
-            assert isinstance(client._transport, _EHBPReVerifyingTransport)
+            # No header transport without a proxy; the user-cache-secret layer
+            # still wraps the sealing transport.
+            assert isinstance(client._transport, _HostBoundTransport)
+            assert isinstance(client._transport._inner, _UserCacheSecretTransport)
+            assert isinstance(client._transport._inner._inner, _EHBPReVerifyingTransport)
         finally:
             client.close()
 
@@ -173,7 +191,12 @@ class TestProxyTransportWiring:
         sc = self._client("https://proxy.example.com/")
         client = sc.make_secure_async_http_client()
         try:
-            assert isinstance(client._transport, _AsyncEnclaveURLHeaderTransport)
+            assert isinstance(client._transport, _AsyncHostBoundTransport)
+            header = client._transport._inner
+            assert isinstance(header, _AsyncEnclaveURLHeaderTransport)
+            ucs = header._inner
+            assert isinstance(ucs, _AsyncUserCacheSecretTransport)
+            assert isinstance(ucs._inner, _AsyncEHBPReVerifyingTransport)
         finally:
             asyncio.run(client.aclose())
 

--- a/tests/test_integration_chat.py
+++ b/tests/test_integration_chat.py
@@ -9,14 +9,17 @@ from tinfoil import TinfoilAI
 
 pytestmark = pytest.mark.integration  # allows pytest -m integration filtering
 
+TEST_USER_CACHE_SECRET = "python-live-integration-cache-secret"
+
 @pytest.fixture(scope="session")
 def client() -> TinfoilAI:
     return TinfoilAI(
         api_key=os.getenv("TINFOIL_API_KEY", "tinfoil"),
+        user_cache_secret=TEST_USER_CACHE_SECRET,
     )
 
 
-def test_basic_chat_completion(client):
+def test_basic_chat_completion_with_cache_secret(client):
     response = client.chat.completions.create(
         messages=[{"role": "user", "content": "Hi"}],
         model="llama3-3-70b",

--- a/tests/test_user_cache_secret.py
+++ b/tests/test_user_cache_secret.py
@@ -1,0 +1,655 @@
+"""
+Tests for user_cache_secret provisioning (per-user prompt cache scoping).
+
+The router derives the request's prefix-cache namespace from the
+`user_cache_secret` body field: requests carrying the same secret share cached
+prompt prefixes, requests carrying different secrets cannot observe each
+other's cache timing. The SDK provisions the field automatically — explicit
+parameter, then TINFOIL_USER_CACHE_SECRET, then a secret persisted at
+~/.tinfoil/user_cache_secret — and injects it inside the sealing transport so
+it only ever travels encrypted.
+"""
+
+import asyncio
+import json
+import os
+import stat
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from openai import AsyncOpenAI, OpenAI
+
+import tinfoil.user_cache_secret as user_cache_secret_module
+from tinfoil import SecureClient
+from tinfoil.client import (
+    GroundTruth,
+    _AsyncEHBPReVerifyingTransport,
+    _AsyncHostBoundTransport,
+    _EHBPReVerifyingTransport,
+    _HostBoundTransport,
+    _ReVerifyingTransport,
+)
+from tinfoil.user_cache_secret import (
+    USER_CACHE_SECRET_DIR_NAME,
+    USER_CACHE_SECRET_ENV,
+    USER_CACHE_SECRET_FIELD,
+    USER_CACHE_SECRET_FILE_NAME,
+    _AsyncUserCacheSecretTransport,
+    _UserCacheSecretTransport,
+    resolve_user_cache_secret,
+)
+
+
+@pytest.fixture
+def secret_home(monkeypatch, tmp_path):
+    """A tmp home directory with TINFOIL_USER_CACHE_SECRET removed, so
+    resolution falls through to the persisted/generated secret."""
+    monkeypatch.delenv(USER_CACHE_SECRET_ENV, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+class TestResolvePrecedence:
+    def test_explicit_parameter_beats_environment(self, monkeypatch):
+        monkeypatch.setenv(USER_CACHE_SECRET_ENV, "from-env")
+        assert resolve_user_cache_secret("explicit") == "explicit"
+
+    def test_explicit_empty_disables_even_with_environment_set(self, monkeypatch):
+        # An explicit empty secret still counts as "set": it disables
+        # provisioning rather than falling through to the environment.
+        monkeypatch.setenv(USER_CACHE_SECRET_ENV, "from-env")
+        assert resolve_user_cache_secret("") == ""
+
+    def test_environment_beats_generation_and_touches_no_file(self, secret_home, monkeypatch):
+        monkeypatch.setenv(USER_CACHE_SECRET_ENV, "from-env")
+        assert resolve_user_cache_secret(None) == "from-env"
+        assert not (secret_home / USER_CACHE_SECRET_DIR_NAME).exists(), (
+            "an environment-provided secret must not create the secret file"
+        )
+
+    def test_environment_set_but_empty_disables_generation(self, secret_home, monkeypatch):
+        monkeypatch.setenv(USER_CACHE_SECRET_ENV, "")
+        assert resolve_user_cache_secret(None) == ""
+        assert not (secret_home / USER_CACHE_SECRET_DIR_NAME).exists(), (
+            "a disabled secret must not create the secret file"
+        )
+
+
+class TestPersistence:
+    def test_generates_and_persists(self, secret_home):
+        first = resolve_user_cache_secret(None)
+        assert len(first) == 64
+        assert set(first) <= set("0123456789abcdef")
+
+        secret_dir = secret_home / USER_CACHE_SECRET_DIR_NAME
+        path = secret_dir / USER_CACHE_SECRET_FILE_NAME
+        assert stat.S_IMODE(secret_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        assert path.read_text() == first
+        assert resolve_user_cache_secret(None) == first
+        assert list(secret_dir.iterdir()) == [path]
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permissions only")
+    def test_accepts_permissive_preexisting_modes(self, secret_home):
+        secret_dir = secret_home / USER_CACHE_SECRET_DIR_NAME
+        secret_dir.mkdir()
+        path = secret_dir / USER_CACHE_SECRET_FILE_NAME
+        path.write_text("shared-secret")
+        secret_dir.chmod(0o777)
+        path.chmod(0o666)
+
+        assert resolve_user_cache_secret(None) == "shared-secret"
+        assert stat.S_IMODE(secret_dir.stat().st_mode) == 0o777
+        assert stat.S_IMODE(path.stat().st_mode) == 0o666
+
+    def test_adopts_existing_file_with_unicode_whitespace(self, secret_home):
+        secret_dir = secret_home / USER_CACHE_SECRET_DIR_NAME
+        secret_dir.mkdir(mode=0o700)
+        path = secret_dir / USER_CACHE_SECRET_FILE_NAME
+        path.write_text("\u2003shared-secret\n")
+
+        assert resolve_user_cache_secret(None) == "shared-secret"
+        assert path.read_text() == "\u2003shared-secret\n"
+
+    def test_preserves_non_unicode_separator_controls(self, secret_home):
+        secret_dir = secret_home / USER_CACHE_SECRET_DIR_NAME
+        secret_dir.mkdir(mode=0o700)
+        (secret_dir / USER_CACHE_SECRET_FILE_NAME).write_text(
+            "\x1cshared-secret\x1f"
+        )
+
+        assert resolve_user_cache_secret(None) == "\x1cshared-secret\x1f"
+
+    @pytest.mark.parametrize(
+        "contents", [b"  \n", b"\xff\xfegarbage"], ids=["blank", "invalid-utf8"]
+    )
+    def test_unusable_existing_file_is_untouched(
+        self, secret_home, monkeypatch, contents
+    ):
+        secret_dir = secret_home / USER_CACHE_SECRET_DIR_NAME
+        secret_dir.mkdir(mode=0o700)
+        path = secret_dir / USER_CACHE_SECRET_FILE_NAME
+        path.write_bytes(contents)
+        monkeypatch.setattr(
+            user_cache_secret_module,
+            "_ephemeral_user_cache_secret",
+            lambda: "ephemeral",
+        )
+
+        assert resolve_user_cache_secret(None) == "ephemeral"
+        assert path.read_bytes() == contents
+
+    @pytest.mark.skipif(os.name == "nt", reason="O_NOFOLLOW is POSIX")
+    def test_rejects_secret_file_symlink_without_reading_target(
+        self, secret_home, monkeypatch
+    ):
+        secret_dir = secret_home / USER_CACHE_SECRET_DIR_NAME
+        secret_dir.mkdir()
+        path = secret_dir / USER_CACHE_SECRET_FILE_NAME
+        target = secret_home / "symlink-target"
+        target.write_text("target-secret")
+        path.symlink_to(target)
+        monkeypatch.setattr(
+            user_cache_secret_module,
+            "_ephemeral_user_cache_secret",
+            lambda: "ephemeral",
+        )
+
+        assert resolve_user_cache_secret(None) == "ephemeral"
+        assert target.read_text() == "target-secret"
+
+    @pytest.mark.skipif(os.name == "nt", reason="FIFO files are POSIX")
+    def test_rejects_non_regular_secret_file(self, secret_home, monkeypatch):
+        secret_dir = secret_home / USER_CACHE_SECRET_DIR_NAME
+        secret_dir.mkdir()
+        path = secret_dir / USER_CACHE_SECRET_FILE_NAME
+        os.mkfifo(path, mode=0o644)
+        monkeypatch.setattr(
+            user_cache_secret_module,
+            "_ephemeral_user_cache_secret",
+            lambda: "ephemeral",
+        )
+
+        assert resolve_user_cache_secret(None) == "ephemeral"
+        assert stat.S_ISFIFO(path.stat().st_mode)
+
+    @pytest.mark.skipif(os.name == "nt", reason="directory symlinks are POSIX")
+    def test_rejects_cache_directory_symlink(self, secret_home, monkeypatch):
+        target = secret_home / "directory-target"
+        target.mkdir(mode=0o755)
+        secret_dir = secret_home / USER_CACHE_SECRET_DIR_NAME
+        secret_dir.symlink_to(target, target_is_directory=True)
+        monkeypatch.setattr(
+            user_cache_secret_module,
+            "_ephemeral_user_cache_secret",
+            lambda: "ephemeral",
+        )
+
+        assert resolve_user_cache_secret(None) == "ephemeral"
+        assert list(target.iterdir()) == []
+
+    @pytest.mark.skipif(os.name == "nt", reason="hard-link election is POSIX")
+    def test_concurrent_first_use_converges(self, secret_home):
+        script = textwrap.dedent(
+            """
+            import sys
+            from tinfoil.user_cache_secret import resolve_user_cache_secret
+
+            sys.stdin.read(1)
+            print(resolve_user_cache_secret(None))
+            """
+        )
+        env = os.environ.copy()
+        env["HOME"] = str(secret_home)
+        env.pop(USER_CACHE_SECRET_ENV, None)
+        source_dir = str(Path(__file__).parents[1] / "src")
+        env["PYTHONPATH"] = os.pathsep.join(
+            value for value in (source_dir, env.get("PYTHONPATH")) if value
+        )
+        processes = [
+            subprocess.Popen(
+                [sys.executable, "-c", script],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+            )
+            for _ in range(12)
+        ]
+        for process in processes:
+            assert process.stdin is not None
+            process.stdin.write("x")
+            process.stdin.close()
+
+        results = []
+        for process in processes:
+            assert process.stdout is not None
+            assert process.stderr is not None
+            stdout = process.stdout.read()
+            stderr = process.stderr.read()
+            assert process.wait(timeout=30) == 0, stderr
+            results.append(stdout.strip())
+
+        path = (
+            secret_home
+            / USER_CACHE_SECRET_DIR_NAME
+            / USER_CACHE_SECRET_FILE_NAME
+        )
+        assert len(set(results)) == 1
+        assert results[0] == path.read_text()
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        assert list(path.parent.iterdir()) == [path]
+
+    def test_hard_link_failure_uses_process_fallback(
+        self, secret_home, monkeypatch
+    ):
+        monkeypatch.setattr(
+            user_cache_secret_module.os,
+            "link",
+            lambda source, destination: (_ for _ in ()).throw(
+                OSError("hard links unavailable")
+            ),
+        )
+        monkeypatch.setattr(
+            user_cache_secret_module,
+            "_ephemeral_user_cache_secret",
+            lambda: "ephemeral",
+        )
+
+        assert resolve_user_cache_secret(None) == "ephemeral"
+        secret_dir = secret_home / USER_CACHE_SECRET_DIR_NAME
+        assert list(secret_dir.iterdir()) == []
+
+    @pytest.mark.parametrize("home", [None, ""], ids=["unset", "empty"])
+    def test_falls_back_without_home(self, monkeypatch, home):
+        monkeypatch.delenv(USER_CACHE_SECRET_ENV, raising=False)
+        if home is None:
+            monkeypatch.delenv("HOME", raising=False)
+        else:
+            monkeypatch.setenv("HOME", home)
+
+        first = resolve_user_cache_secret(None)
+        assert first
+        assert resolve_user_cache_secret(None) == first
+
+    def test_falls_back_on_pathological_secret_path(self, monkeypatch):
+        monkeypatch.delenv(USER_CACHE_SECRET_ENV, raising=False)
+        monkeypatch.setattr(
+            user_cache_secret_module,
+            "_user_cache_secret_path",
+            lambda: Path("nul\x00l") / USER_CACHE_SECRET_FILE_NAME,
+        )
+
+        assert resolve_user_cache_secret(None)
+
+    def test_falls_back_when_home_not_a_directory(self, monkeypatch, tmp_path):
+        monkeypatch.delenv(USER_CACHE_SECRET_ENV, raising=False)
+        home_file = tmp_path / "not-a-dir"
+        home_file.write_text("x")
+        monkeypatch.setenv("HOME", str(home_file))
+
+        assert resolve_user_cache_secret(None)
+
+
+class _RecordingTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
+    """Records the request and body the injection transport forwards."""
+
+    def __init__(self) -> None:
+        self.request = None
+        self.body = None
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.request = request
+        self.body = request.read()
+        return httpx.Response(200, content=b"ok")
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.request = request
+        self.body = await request.aread()
+        return httpx.Response(200, content=b"ok")
+
+
+def _roundtrip(secret: str, request: httpx.Request, use_async: bool):
+    """Send request through the sync or async injection transport and return
+    (recorder, response)."""
+    recorder = _RecordingTransport()
+    if use_async:
+        async_transport = _AsyncUserCacheSecretTransport(secret, recorder)
+        response = asyncio.run(async_transport.handle_async_request(request))
+    else:
+        transport = _UserCacheSecretTransport(secret, recorder)
+        response = transport.handle_request(request)
+    return recorder, response
+
+
+def _post(path: str, body: bytes) -> httpx.Request:
+    return httpx.Request(
+        "POST",
+        f"https://enclave.test{path}",
+        headers={"Content-Type": "application/json"},
+        content=body,
+    )
+
+
+@pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+class TestTransportInjects:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/responses",
+            "/api/v1/chat/completions",  # proxy base URL with a path prefix
+            "/chat/completions",  # custom base URL without a /v1 root
+        ],
+    )
+    def test_injects_on_eligible_paths(self, path, use_async):
+        recorder, response = _roundtrip("s1", _post(path, b'{"model":"m"}'), use_async)
+        assert response.status_code == 200
+
+        body = json.loads(recorder.body)
+        assert body[USER_CACHE_SECRET_FIELD] == "s1"
+        assert body["model"] == "m"
+
+        # Length metadata and the replayable body must describe the injected
+        # bytes: retries below this layer (EHBP key rotation) re-read the
+        # request stream.
+        assert recorder.request.headers["Content-Length"] == str(len(recorder.body))
+        assert b"".join(recorder.request.stream) == recorder.body
+
+    def test_trailing_whitespace_still_injected(self, use_async):
+        # Trailing whitespace is not trailing data: strict JSON parsers accept
+        # it, so the injection must too — clients routinely end bodies with \n.
+        recorder, _ = _roundtrip(
+            "s1", _post("/v1/chat/completions", b'{"model":"m"}\n\t '), use_async
+        )
+        assert recorder.body == b'{"model":"m","user_cache_secret":"s1"}\n\t '
+
+    def test_preserves_number_precision(self, use_async):
+        # 2^53+1 is not representable as float64; a decode/re-encode through
+        # floats would corrupt it.
+        recorder, _ = _roundtrip(
+            "s1",
+            _post("/v1/chat/completions", b'{"model":"m","seed":9007199254740993}'),
+            use_async,
+        )
+        assert b'"seed":9007199254740993' in recorder.body
+        assert json.loads(recorder.body)[USER_CACHE_SECRET_FIELD] == "s1"
+
+
+@pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+class TestTransportSkips:
+    @pytest.mark.parametrize("path", ["/v1/embeddings", "/embeddings"])
+    def test_non_allowlisted_endpoint_forwards_body_untouched(self, path, use_async):
+        raw = b'{"model":"m","input":"text"}'
+        request = _post(path, raw)
+        recorder, _ = _roundtrip("s1", request, use_async)
+        assert recorder.body == raw
+        assert recorder.request is request
+
+    def test_get_with_no_body_forwarded_as_is(self, use_async):
+        request = httpx.Request("GET", "https://enclave.test/v1/models")
+        recorder, response = _roundtrip("s1", request, use_async)
+        assert response.status_code == 200
+        assert recorder.request is request
+
+    def test_post_with_empty_body_forwarded_as_is(self, use_async):
+        request = _post("/v1/chat/completions", b"")
+        recorder, _ = _roundtrip("s1", request, use_async)
+        assert recorder.body == b""
+        assert recorder.request is request
+
+    def test_empty_secret_disables_injection(self, use_async):
+        raw = b'{"model":"m"}'
+        request = _post("/v1/chat/completions", raw)
+        recorder, _ = _roundtrip("", request, use_async)
+        assert recorder.body == raw
+        assert recorder.request is request
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            b'{"model":"m","user_cache_secret":"end-user-7"}',
+            b'{"model":"m","user_cache_secret":""}',
+        ],
+        ids=["explicit per-request secret", "explicit empty opt-out"],
+    )
+    def test_never_clobbers_a_present_field(self, raw, use_async):
+        request = _post("/v1/chat/completions", raw)
+        recorder, _ = _roundtrip("client-level", request, use_async)
+        assert recorder.body == raw, (
+            "a body that already carries the field must pass through byte-identical"
+        )
+        assert recorder.request is request
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            b"not json",
+            b"[1,2,3]",
+            b"null",
+            b'{"model":"m"} trailing',
+            b'{"model":"m"}}',
+            b'{"model":"m"}]',
+            b'{"model":"m"}} garbage',
+        ],
+    )
+    def test_non_object_bodies_forwarded_untouched(self, raw, use_async):
+        # The trailing '}' / ']' cases matter: a parser that stops at the end
+        # of the object would re-serialize with the trailing bytes silently
+        # dropped, quietly turning a request the server rejects into one it
+        # accepts.
+        request = _post("/v1/chat/completions", raw)
+        recorder, _ = _roundtrip("s1", request, use_async)
+        assert recorder.body == raw, (
+            "bodies the router-side schema would reject must be forwarded untouched"
+        )
+        assert recorder.request is request
+
+    def test_pathologically_nested_body_forwarded_untouched(self, use_async):
+        # CPython's json scanner raises RecursionError on very deep nesting
+        # (Go's decoder errors at its own depth limit): the body must be
+        # forwarded untouched — never a RecursionError out of the transport.
+        raw = b'{"a":' + b"[" * 1_000_000 + b"]" * 1_000_000 + b"}"
+        request = _post("/v1/chat/completions", raw)
+        recorder, _ = _roundtrip("s1", request, use_async)
+        assert recorder.body == raw
+        assert recorder.request is request
+
+
+class TestStreamingBodies:
+    """Streaming bodies are forwarded without being consumed."""
+
+    def test_sync_streaming_body_unchanged(self):
+        request = httpx.Request(
+            "POST",
+            "https://enclave.test/v1/chat/completions",
+            headers={"tRaNsFeR-EnCoDiNg": "chunked"},
+            content=iter([b'{"model":', b'"m"}']),
+        )
+        recorder, _ = _roundtrip("s1", request, use_async=False)
+        assert recorder.request is request
+        assert recorder.body == b'{"model":"m"}'
+        assert recorder.request.headers["Transfer-Encoding"] == "chunked"
+
+    def test_async_streaming_body_unchanged(self):
+        async def chunks():
+            yield b'{"model":'
+            yield b'"m"}'
+
+        request = httpx.Request(
+            "POST",
+            "https://enclave.test/v1/chat/completions",
+            headers={"TrAnSfEr-EnCoDiNg": "chunked"},
+            content=chunks(),
+        )
+        recorder, _ = _roundtrip("s1", request, use_async=True)
+        assert recorder.request is request
+        assert recorder.body == b'{"model":"m"}'
+        assert recorder.request.headers["Transfer-Encoding"] == "chunked"
+
+
+def _hpke_hex() -> str:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+
+    pk = X25519PrivateKey.generate().public_key()
+    return pk.public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw
+    ).hex()
+
+
+def _secure_client(**kwargs) -> SecureClient:
+    # An explicit enclave avoids the router lookup (network) in __init__.
+    sc = SecureClient(enclave="enclave.test", repo="org/repo", **kwargs)
+    sc.verify = MagicMock(
+        return_value=GroundTruth(
+            public_key="fp", digest="d", measurement="m", hpke_public_key=_hpke_hex()
+        )
+    )
+    return sc
+
+
+class TestSecureClientResolution:
+    """SecureClient resolves the client-level secret once at construction; the
+    conftest fixture pins TINFOIL_USER_CACHE_SECRET=test-secret."""
+
+    def test_explicit_parameter_wins(self):
+        assert _secure_client(user_cache_secret="s1")._user_cache_secret == "s1"
+
+    def test_explicit_empty_counts_as_set_and_disables(self):
+        assert _secure_client(user_cache_secret="")._user_cache_secret == ""
+
+    def test_unset_falls_back_to_environment(self):
+        assert _secure_client()._user_cache_secret == "test-secret"
+
+
+class TestSecureClientWiring:
+    """The cache-secret layer must sit inside any header-level wrapping and
+    above the sealing transport, so the injected field is encrypted with the
+    rest of the body — and it must be omitted when the secret is empty."""
+
+    def test_sync_ehbp_stack(self):
+        client = _secure_client().make_secure_http_client()
+        try:
+            bound = client._transport
+            assert isinstance(bound, _HostBoundTransport)
+            ucs = bound._inner
+            assert isinstance(ucs, _UserCacheSecretTransport)
+            assert isinstance(ucs._inner, _EHBPReVerifyingTransport)
+        finally:
+            client.close()
+
+    def test_sync_tls_stack(self):
+        client = _secure_client(transport="tls").make_secure_http_client()
+        try:
+            bound = client._transport
+            assert isinstance(bound, _HostBoundTransport)
+            ucs = bound._inner
+            assert isinstance(ucs, _UserCacheSecretTransport)
+            assert isinstance(ucs._inner, _ReVerifyingTransport)
+        finally:
+            client.close()
+
+    def test_async_ehbp_stack(self):
+        client = _secure_client().make_secure_async_http_client()
+        try:
+            bound = client._transport
+            assert isinstance(bound, _AsyncHostBoundTransport)
+            ucs = bound._inner
+            assert isinstance(ucs, _AsyncUserCacheSecretTransport)
+            assert isinstance(ucs._inner, _AsyncEHBPReVerifyingTransport)
+        finally:
+            asyncio.run(client.aclose())
+
+    def test_empty_secret_omits_the_layer(self):
+        client = _secure_client(user_cache_secret="").make_secure_http_client()
+        try:
+            assert isinstance(client._transport, _HostBoundTransport)
+            assert isinstance(client._transport._inner, _EHBPReVerifyingTransport)
+        finally:
+            client.close()
+
+
+def _chat_completion_handler(received: list):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/chat/completions"
+        received.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "id": "c1",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "m",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+        )
+
+    return handler
+
+
+class TestThroughOpenAIClient:
+    """Drives the real OpenAI client through the injection transport to a mock
+    server, pinning that the secret rides requests exactly as the SDK builds
+    them — and that a per-request field set via the public API (extra_body)
+    wins over the client-level secret."""
+
+    _params = {"model": "m", "messages": [{"role": "user", "content": "hi"}]}
+
+    def test_sync_client(self):
+        received: list = []
+        http_client = httpx.Client(
+            transport=_UserCacheSecretTransport(
+                "client-level", httpx.MockTransport(_chat_completion_handler(received))
+            )
+        )
+        oai = OpenAI(api_key="test", base_url="http://localhost/v1", http_client=http_client)
+
+        oai.chat.completions.create(**self._params)
+        assert received[-1][USER_CACHE_SECRET_FIELD] == "client-level"
+
+        oai.chat.completions.create(
+            **self._params, extra_body={USER_CACHE_SECRET_FIELD: "end-user-7"}
+        )
+        assert received[-1][USER_CACHE_SECRET_FIELD] == "end-user-7", (
+            "a per-request field must win over the client-level secret"
+        )
+
+    def test_async_client(self):
+        received: list = []
+
+        async def run():
+            http_client = httpx.AsyncClient(
+                transport=_AsyncUserCacheSecretTransport(
+                    "client-level",
+                    httpx.MockTransport(_chat_completion_handler(received)),
+                )
+            )
+            oai = AsyncOpenAI(
+                api_key="test", base_url="http://localhost/v1", http_client=http_client
+            )
+
+            await oai.chat.completions.create(**self._params)
+            assert received[-1][USER_CACHE_SECRET_FIELD] == "client-level"
+
+            await oai.chat.completions.create(
+                **self._params, extra_body={USER_CACHE_SECRET_FIELD: "end-user-7"}
+            )
+            assert received[-1][USER_CACHE_SECRET_FIELD] == "end-user-7", (
+                "a per-request field must win over the client-level secret"
+            )
+
+        asyncio.run(run())

--- a/tests/test_verification_failures.py
+++ b/tests/test_verification_failures.py
@@ -398,11 +398,13 @@ class TestAsyncTLSPinning:
 
     def _get_ssl_context(self, async_http_client):
         """Extract the SSL context from an httpx.AsyncClient."""
+        # The transport is wrapped with the user-cache-secret injection layer
+        # and _AsyncReVerifyingTransport for long-lived client support; unwrap
+        # to reach the real httpx transport.
         transport = async_http_client._transport
-        # The transport is wrapped with _AsyncReVerifyingTransport for
-        # long-lived client support; unwrap to reach the real httpx transport.
-        inner = getattr(transport, "_inner", transport)
-        return inner._pool._ssl_context
+        while hasattr(transport, "_inner"):
+            transport = transport._inner
+        return transport._pool._ssl_context
 
     def _call_pinned_wrap_bio(self, ssl_ctx, fake_ssl_object):
         """

--- a/uv.lock
+++ b/uv.lock
@@ -966,7 +966,7 @@ wheels = [
 
 [[package]]
 name = "tinfoil"
-version = "0.13.3"
+version = "0.13.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds per-user prompt cache scoping by injecting a `user_cache_secret` into eligible OpenAI POSTs before EHBP/pinned-TLS sealing, and hard-binds all HTTP requests to the verified enclave or configured proxy. Published as 0.13.4; README documents setup and examples.

- **New Features**
  - Client config/env: `user_cache_secret` on `TinfoilAI`/`AsyncTinfoilAI`/`NewSecureClient`; `TINFOIL_USER_CACHE_SECRET` respected; `""` disables. Resolution: per-request body (wins, incl. explicit `""`) > client param > env > persisted at `~/.tinfoil/user_cache_secret`; no home/RO FS → in-memory fallback; CSPRNG failure disables injection.
  - Transport injection runs before EHBP/pinned-TLS and above re-verifying retries; applies to POSTs for `/chat/completions`, `/completions`, `/responses` via path-suffix match (works with custom base URLs). Raw splice preserves caller bytes and number precision; trailing JSON whitespace allowed; non-object/invalid JSON and streaming bodies pass through unchanged; `extra_body.user_cache_secret` always wins.

- **Bug Fixes**
  - Every request is host-bound to the verified enclave or configured proxy; redirects remain disabled, and OpenAI `base_url` overrides that change origin are blocked.
  - Retries replay injected bytes correctly: buffered bodies drop `Transfer-Encoding` and set `Content-Length`.
  - Secret persistence hardened: directory/file modes `0700`/`0600`, atomic publish via hard-link election; symlinks/reparse points and non-regular files rejected; invalid UTF-8/blank files treated as unusable without rewrites; concurrency elects a single winner.

<sup>Written for commit 8d090eaef959e878fcaea5fecab5959424d2a4d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-python/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

