### PR TITLE
chore: bump version to 0.13.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ sbom-files = ["sbom.cdx.json"]
 
 [project]
 name = "tinfoil"
-version = "0.13.1"
+version = "0.13.2"
 description = "Python client for Tinfoil"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump for the 0.13.2 release (MR_SEAM whitelist update).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `tinfoil` 0.13.2 to publish the MR_SEAM whitelist update. Version-only change in pyproject; no functional code changes.

<sup>Written for commit 5aa95c98e9c9be08af84d815088ed6852d150e86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-python/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

