### PR TITLE
chore: update uv.lock for 0.13.2

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-06-01T14:49:05.964396Z"
+exclude-newer = "2026-07-05T20:59:34.914005Z"
 exclude-newer-span = "P4D"
 
 [options.exclude-newer-package]
@@ -966,7 +966,7 @@ wheels = [
 
 [[package]]
 name = "tinfoil"
-version = "0.13.1"
+version = "0.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
The 0.13.2 version bump did not update uv.lock, so `uv sync --locked` fails in CI (Test on main and the SBOM step of the v0.13.2 release).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `uv.lock` to align with v0.13.2 by bumping `tinfoil` to 0.13.2 and refreshing `exclude-newer`, fixing `uv sync --locked` failures in CI (main tests and SBOM).

<sup>Written for commit 4c729f5cbc8718df9cd131fad73c9753aef90940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-python/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

