### PR TITLE
chore: bump version to 0.13.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ sbom-files = ["sbom.cdx.json"]
 
 [project]
 name = "tinfoil"
-version = "0.13.2"
+version = "0.13.3"
 description = "Python client for Tinfoil"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-07-05T20:59:34.914005Z"
+exclude-newer = "2026-07-05T21:24:28.192884Z"
 exclude-newer-span = "P4D"
 
 [options.exclude-newer-package]
@@ -966,7 +966,7 @@ wheels = [
 
 [[package]]
 name = "tinfoil"
-version = "0.13.2"
+version = "0.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Version bump for the 0.13.3 release. The v0.13.2 tag points at a commit with a stale uv.lock and tags cannot be deleted, so 0.13.2 is skipped (it was never published to PyPI).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `tinfoil` to 0.13.3 and refresh the lockfile to align with the new version for a clean PyPI release. Skips 0.13.2 since its tag points to a commit with a stale `uv.lock` and it was never published.

<sup>Written for commit b771a3608c19bc1f6dbf0253adb40ef02cdd3214. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-python/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

