### PR TITLE
fix: align proxy transport requirements

### DIFF
--- a/src/tinfoil/__init__.py
+++ b/src/tinfoil/__init__.py
@@ -28,7 +28,7 @@ class TinfoilAI:
         measurement: Optional[dict] = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
         transport: TransportMode = DEFAULT_TRANSPORT_MODE,
-        base_url: str = "",
+        base_url: Optional[str] = None,
         attestation_bundle_url: str = "",
     ):
         if measurement is not None:
@@ -82,7 +82,7 @@ class AsyncTinfoilAI:
         measurement: Optional[dict] = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
         transport: TransportMode = DEFAULT_TRANSPORT_MODE,
-        base_url: str = "",
+        base_url: Optional[str] = None,
         attestation_bundle_url: str = "",
     ):
         if measurement is not None:
@@ -144,7 +144,7 @@ class _HTTPSecureClient:
         return self._http_client.post(url, headers=headers, data=data, json=json, timeout=timeout)
 
 
-def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE, base_url: str = "", attestation_bundle_url: str = ""):
+def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE, base_url: Optional[str] = None, attestation_bundle_url: str = ""):
     """Create a secure HTTP client for direct GET/POST through the Tinfoil enclave."""
     if measurement is not None:
         repo = ""

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -56,6 +56,31 @@ TransportMode = Literal["ehbp", "tls"]
 DEFAULT_TRANSPORT_MODE: TransportMode = "ehbp"
 
 
+def _parse_http_url(url: str, parameter: str, *, https_only: bool = False):
+    try:
+        parsed = urlparse(url)
+        parsed.port
+    except ValueError as exc:
+        raise ValueError(f"{parameter} must be a valid absolute URL; got {url!r}") from exc
+
+    scheme = parsed.scheme.lower()
+    allowed_schemes = ("https",) if https_only else ("http", "https")
+    if scheme not in allowed_schemes or not parsed.netloc or not parsed.hostname:
+        requirement = "https" if https_only else "http or https"
+        raise ValueError(
+            f"{parameter} must be a valid absolute URL using {requirement}; got {url!r}"
+        )
+    return parsed
+
+
+def _url_origin(url: str) -> tuple[str, str, int]:
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    default_port = 443 if scheme == "https" else 80
+    port = parsed.port if parsed.port is not None else default_port
+    return scheme, parsed.hostname or "", port
+
+
 class _PinMismatchError(ValueError):
     """
     Raised when the enclave's TLS certificate fails our pin check (wrong
@@ -397,11 +422,7 @@ def _enclave_url_header(base_url: str, enclave: str) -> tuple[str, bool]:
     if not base_url or not enclave:
         return "", False
     enclave_url = f"https://{enclave}"
-    proxy = urlparse(base_url)
-    if not proxy.netloc:
-        return "", False
-    enclave_parsed = urlparse(enclave_url)
-    if (proxy.scheme, proxy.netloc) == (enclave_parsed.scheme, enclave_parsed.netloc):
+    if _url_origin(base_url) == _url_origin(enclave_url):
         return "", False
     return enclave_url, True
 
@@ -451,7 +472,7 @@ class _AsyncEnclaveURLHeaderTransport(httpx.AsyncBaseTransport):
 class SecureClient:
     """A client that verifies and communicates with secure enclaves"""
     
-    def __init__(self, enclave: str = "", repo: str = DEFAULT_CONFIG_REPO, measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE, base_url: str = "", attestation_bundle_url: str = ""):
+    def __init__(self, enclave: str = "", repo: str = DEFAULT_CONFIG_REPO, measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE, base_url: Optional[str] = None, attestation_bundle_url: str = ""):
         # Hardcoded measurement takes precedence over repo
         if measurement is not None:
             repo = ""
@@ -472,23 +493,18 @@ class SecureClient:
                 "the bundle provides its own code measurement."
             )
 
-        # EHBP and TLS pinning leave request headers (which may carry the API
-        # key) in plaintext, so a proxy base URL must be https.
-        if base_url and urlparse(base_url).scheme != "https":
-            raise ValueError(f"base_url must use https; got {base_url!r}")
+        if base_url is not None:
+            _parse_http_url(base_url, "base_url")
 
         # The attestation bundle is the entire trust root for verification.
         # Fetching it over plaintext would let an attacker substitute the bundle
         # (MITM), so the bundle URL must be https.
-        if attestation_bundle_url and urlparse(attestation_bundle_url).scheme != "https":
-            raise ValueError(
-                f"attestation_bundle_url must use https; got {attestation_bundle_url!r}"
+        if attestation_bundle_url:
+            _parse_http_url(
+                attestation_bundle_url,
+                "attestation_bundle_url",
+                https_only=True,
             )
-
-        # Routing through a proxy base URL relies on EHBP sealing the body to the
-        # enclave; TLS certificate pinning would reject the proxy's certificate.
-        if base_url and transport != "ehbp":
-            raise ValueError("base_url is only supported with the 'ehbp' transport")
 
         # If enclave is empty, fetch a random one from the routers API. When
         # attesting from a bundle, the enclave host comes from the verified
@@ -500,11 +516,12 @@ class SecureClient:
         self.repo = repo
         self.measurement = measurement
         self.transport = transport
-        self.base_url = base_url
+        self.base_url = base_url or ""
         self.attestation_bundle_url = attestation_bundle_url
         self._ground_truth: Optional[GroundTruth] = None
         self._verification_document: Optional[VerificationDocument] = None
         self._low_level_http_client: Optional[httpx.Client] = None
+        self._validate_tls_base_url()
 
     @property
     def ground_truth(self) -> Optional[GroundTruth]:
@@ -562,14 +579,27 @@ class SecureClient:
     def _rebuild_sync_transport(self) -> httpx.BaseTransport:
         """Re-run attestation and return a fresh sync httpx transport."""
         expected_fp = self.verify().public_key
+        self._validate_tls_base_url()
         ctx = self._build_sync_ssl_context(expected_fp)
         return httpx.HTTPTransport(verify=ctx)
 
     async def _rebuild_async_transport(self) -> httpx.AsyncBaseTransport:
         """Re-run attestation without blocking the event loop."""
         expected_fp = (await asyncio.to_thread(self.verify)).public_key
+        self._validate_tls_base_url()
         ctx = self._build_async_ssl_context(expected_fp)
         return httpx.AsyncHTTPTransport(verify=ctx)
+
+    def _validate_tls_base_url(self) -> None:
+        if self.transport != "tls" or not self.base_url or not self.enclave:
+            return
+        enclave_url = f"https://{self.enclave}"
+        enclave_origin = _url_origin(enclave_url)
+        if _url_origin(self.base_url) != enclave_origin:
+            raise ValueError(
+                "TLS base_url must use the verified enclave origin "
+                f"{enclave_url!r}"
+            )
 
     def _require_hpke_public_key(self) -> str:
         """Re-run attestation and return the attested HPKE public key."""
@@ -605,8 +635,8 @@ class SecureClient:
         the request once.
 
         Redirects are not followed: a redirect target bypasses the enclave/proxy
-        host binding, so following one could leak plaintext headers (including
-        the API key) to an arbitrary host.
+        host binding, so following one could disclose sensitive headers
+        (including the API key) to an arbitrary host.
         """
         if self.transport == "ehbp":
             inner = self._build_ehbp_sync_transport()
@@ -616,6 +646,7 @@ class SecureClient:
             return httpx.Client(transport=transport, follow_redirects=False)
 
         expected_fp = self.verify().public_key
+        self._validate_tls_base_url()
         ctx = self._build_sync_ssl_context(expected_fp)
         inner = httpx.HTTPTransport(verify=ctx)
         transport = _ReVerifyingTransport(self, inner)
@@ -635,8 +666,8 @@ class SecureClient:
         the request once.
 
         Redirects are not followed: a redirect target bypasses the enclave/proxy
-        host binding, so following one could leak plaintext headers (including
-        the API key) to an arbitrary host.
+        host binding, so following one could disclose sensitive headers
+        (including the API key) to an arbitrary host.
         """
         if self.transport == "ehbp":
             hpke_public_key = self._require_hpke_public_key()
@@ -647,6 +678,7 @@ class SecureClient:
             return httpx.AsyncClient(transport=transport, follow_redirects=False)
 
         expected_fp = self.verify().public_key
+        self._validate_tls_base_url()
         ctx = self._build_async_ssl_context(expected_fp)
         inner = httpx.AsyncHTTPTransport(verify=ctx)
         transport = _AsyncReVerifyingTransport(self, inner)
@@ -860,6 +892,7 @@ class SecureClient:
         """
         if not self._ground_truth:
             self._ground_truth = self.verify()
+        self._validate_tls_base_url()
 
         if self.transport == "ehbp":
             raise ValueError(
@@ -877,30 +910,25 @@ class SecureClient:
             self._low_level_http_client = self.make_secure_http_client()
         return self._low_level_http_client
 
-    def _allowed_request_endpoints(self) -> set:
-        """(host, port) pairs a request may target: the attested enclave and, if set, the proxy."""
-        endpoints = set()
-        enclave = urlparse(f"//{self.enclave}")
-        if enclave.hostname:
-            endpoints.add((enclave.hostname, enclave.port or 443))
+    def _allowed_request_origins(self) -> set:
+        """Origins a request may target: the attested enclave and, if set, the proxy."""
+        origins = set()
+        if self.enclave:
+            origins.add(_url_origin(f"https://{self.enclave}"))
         if self.base_url:
-            proxy = urlparse(self.base_url)
-            if proxy.hostname:
-                endpoints.add((proxy.hostname, proxy.port or 443))
-        return endpoints
+            origins.add(_url_origin(self.base_url))
+        return origins
 
     def assert_request_allowed(self, url: str) -> None:
         """
-        Guards the low-level escape hatches. Neither EHBP nor TLS pinning
-        encrypts request headers (which may carry the API key), so a request may
-        only target the attested enclave or the configured proxy, and only over
-        https. The port is part of the binding so headers cannot be diverted to a
-        different service listening on an allowed host. Raises ValueError otherwise.
+        Guards the low-level escape hatches. EHBP does not encrypt request
+        headers end-to-end; TLS encrypts them in transit, but another endpoint
+        would still receive them. A request may therefore only target the
+        attested enclave or configured proxy over its exact HTTP(S) origin. The
+        scheme and port are part of the binding. Raises ValueError otherwise.
         """
         parsed = urlparse(url)
-        if parsed.scheme != "https":
-            raise ValueError(f"refusing to send request over non-https URL {url!r}")
-        if (parsed.hostname, parsed.port or 443) not in self._allowed_request_endpoints():
+        if _url_origin(url) not in self._allowed_request_origins():
             raise ValueError(
                 f"refusing to send request to host {parsed.hostname!r}: this "
                 f"secure client is bound to enclave {self.enclave!r}"

--- a/tests/test_ehbp_transport.py
+++ b/tests/test_ehbp_transport.py
@@ -113,7 +113,7 @@ class TestTransportSelection:
 class TestRedirectsDisabled:
     """The secure clients must not follow redirects: a redirect target is not
     re-checked against the enclave/proxy host binding, so following one could
-    leak plaintext headers (including the API key) to an arbitrary host."""
+    disclose sensitive headers (including the API key) to an arbitrary host."""
 
     def test_sync_ehbp_client_does_not_follow_redirects(self):
         sc = _secure_client("ehbp")

--- a/tests/test_encrypted_proxy.py
+++ b/tests/test_encrypted_proxy.py
@@ -136,13 +136,13 @@ class TestProxyTransportWiring:
     """make_secure_http_client wraps the EHBP transport with the header
     transport only when routing through a proxy of a different origin."""
 
-    def _client(self, base_url: str):
+    def _client(self, base_url: str | None):
         sc = SecureClient(enclave="enclave.test", repo="org/repo", transport="ehbp", base_url=base_url)
         sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
         return sc
 
     def test_sync_wraps_when_proxying(self):
-        sc = self._client("https://proxy.example.com/")
+        sc = self._client("http://proxy.example.com/")
         client = sc.make_secure_http_client()
         try:
             assert isinstance(client._transport, _EnclaveURLHeaderTransport)
@@ -162,7 +162,7 @@ class TestProxyTransportWiring:
             client.close()
 
     def test_sync_no_wrap_without_base_url(self):
-        sc = self._client("")
+        sc = self._client(None)
         client = sc.make_secure_http_client()
         try:
             assert isinstance(client._transport, _EHBPReVerifyingTransport)
@@ -180,9 +180,9 @@ class TestProxyTransportWiring:
 
 class TestProxyHostBinding:
     """make_request must accept the configured proxy host in addition to the
-    enclave host, and still reject unrelated hosts (headers are plaintext)."""
+    enclave host, and still reject unrelated hosts that could receive headers."""
 
-    def _client_with_mock(self, base_url: str = ""):
+    def _client_with_mock(self, base_url: str | None = None):
         sc = SecureClient(enclave="enclave.test", repo="org/repo", transport="ehbp", base_url=base_url)
         http_client = MagicMock()
         http_client.request.return_value = httpx.Response(200, content=b"ok")
@@ -190,10 +190,10 @@ class TestProxyHostBinding:
         return sc, http_client
 
     def test_allows_proxy_host(self):
-        sc, http_client = self._client_with_mock("https://proxy.example.com/")
-        resp = sc.get("https://proxy.example.com/v1/models")
+        sc, http_client = self._client_with_mock("http://proxy.example.com/")
+        resp = sc.get("http://proxy.example.com/v1/models")
         assert resp.status_code == 200
-        assert http_client.request.call_args.args[1] == "https://proxy.example.com/v1/models"
+        assert http_client.request.call_args.args[1] == "http://proxy.example.com/v1/models"
 
     def test_still_allows_enclave_host(self):
         sc, http_client = self._client_with_mock("https://proxy.example.com/")
@@ -209,9 +209,9 @@ class TestProxyHostBinding:
 
 class TestAssertRequestAllowed:
     """The low-level escape hatches must stay bound to the enclave/proxy host
-    and refuse plaintext (non-https) destinations."""
+    and exact configured origin."""
 
-    def _sc(self, base_url: str = ""):
+    def _sc(self, base_url: str | None = None):
         return SecureClient(enclave="enclave.test", repo="org/repo", transport="ehbp", base_url=base_url)
 
     def test_allows_enclave_https(self):
@@ -220,13 +220,20 @@ class TestAssertRequestAllowed:
     def test_allows_proxy_https(self):
         self._sc("https://proxy.example.com/").assert_request_allowed("https://proxy.example.com/v1/models")
 
+    def test_allows_proxy_http(self):
+        self._sc("http://proxy.example.com/").assert_request_allowed("http://proxy.example.com/v1/models")
+
     def test_rejects_foreign_host(self):
         with pytest.raises(ValueError, match="evil.example.com"):
             self._sc().assert_request_allowed("https://evil.example.com/v1/models")
 
-    def test_rejects_non_https(self):
-        with pytest.raises(ValueError, match="non-https"):
+    def test_rejects_unconfigured_http_origin(self):
+        with pytest.raises(ValueError, match="enclave.test"):
             self._sc().assert_request_allowed("http://enclave.test/v1/models")
+
+    def test_rejects_unsupported_scheme(self):
+        with pytest.raises(ValueError, match="enclave.test"):
+            self._sc().assert_request_allowed("ftp://enclave.test/v1/models")
 
     def test_rejects_non_default_port_on_allowed_host(self):
         with pytest.raises(ValueError, match="enclave.test"):
@@ -240,12 +247,20 @@ class TestAssertRequestAllowed:
         with pytest.raises(ValueError):
             sc.assert_request_allowed("https://proxy.example.com:9000/v1/models")
 
+    def test_http_proxy_uses_port_80_by_default(self):
+        sc = self._sc("http://proxy.example.com/")
+        sc.assert_request_allowed("http://proxy.example.com:80/v1/models")
+        with pytest.raises(ValueError):
+            sc.assert_request_allowed("http://proxy.example.com:443/v1/models")
+        with pytest.raises(ValueError):
+            sc.assert_request_allowed("http://proxy.example.com:0/v1/models")
+
 
 class TestLowLevelHostBinding:
     """NewSecureClient's get()/post() must enforce the host/scheme guard so an
     API key in headers cannot be sent to a caller-supplied host."""
 
-    def _client(self, base_url: str = ""):
+    def _client(self, base_url: str | None = None):
         sc = SecureClient(enclave="enclave.test", repo="org/repo", transport="ehbp", base_url=base_url)
         sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
         client = tinfoil_module._HTTPSecureClient("enclave.test", sc)
@@ -260,9 +275,9 @@ class TestLowLevelHostBinding:
             client.get("https://evil.example.com/v1/models")
         client._http_client.get.assert_not_called()
 
-    def test_post_rejects_non_https(self):
+    def test_post_rejects_unconfigured_http_origin(self):
         client = self._client()
-        with pytest.raises(ValueError, match="non-https"):
+        with pytest.raises(ValueError, match="enclave.test"):
             client.post("http://enclave.test/v1/chat/completions", json={})
         client._http_client.post.assert_not_called()
 
@@ -330,22 +345,50 @@ class TestMatchesHostname:
 
 
 class TestConstructorValidation:
-    """The constructor rejects insecure or contradictory proxy configuration."""
+    """The constructor validates proxy and attestation URL configuration."""
 
-    def test_base_url_must_be_https(self):
-        with pytest.raises(ValueError, match="https"):
-            SecureClient(enclave="enclave.test", repo="org/repo", base_url="http://proxy.example.com/")
+    def test_http_base_url_is_accepted(self):
+        sc = SecureClient(enclave="enclave.test", repo="org/repo", base_url="http://proxy.example.com/")
+        assert sc.base_url == "http://proxy.example.com/"
 
     def test_https_base_url_is_accepted(self):
         sc = SecureClient(enclave="enclave.test", repo="org/repo", base_url="https://proxy.example.com/")
         assert sc.base_url == "https://proxy.example.com/"
 
-    def test_base_url_requires_ehbp_transport(self):
-        with pytest.raises(ValueError, match="ehbp"):
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "",
+            "proxy.example.com",
+            "ftp://proxy.example.com",
+            "https://",
+            "https://proxy.example.com:bad",
+            "://",
+        ],
+    )
+    def test_base_url_must_be_absolute_http_url(self, base_url):
+        with pytest.raises(ValueError, match="valid absolute URL"):
+            SecureClient(enclave="enclave.test", repo="org/repo", base_url=base_url)
+
+    def test_tls_base_url_allows_same_origin_path(self):
+        sc = SecureClient(
+            enclave="enclave.test",
+            repo="org/repo",
+            base_url="https://enclave.test/custom/v1/",
+            transport="tls",
+        )
+        assert sc.base_url == "https://enclave.test/custom/v1/"
+
+    @pytest.mark.parametrize(
+        "base_url",
+        ["https://proxy.example.com/v1/", "http://enclave.test/v1/"],
+    )
+    def test_tls_base_url_rejects_other_origins(self, base_url):
+        with pytest.raises(ValueError, match="verified enclave origin"):
             SecureClient(
                 enclave="enclave.test",
                 repo="org/repo",
-                base_url="https://proxy.example.com/",
+                base_url=base_url,
                 transport="tls",
             )
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Align proxy transport rules by allowing `http` proxies for EHBP and enforcing strict origin binding (scheme, host, port) to prevent header disclosure. `base_url` is now optional and URLs are validated more strictly.

- **Bug Fixes**
  - Accept `http` `base_url` for EHBP; keep `attestation_bundle_url` `https`-only.
  - Validate `base_url`/`attestation_bundle_url` as absolute `http(s)` URLs; reject malformed or non-HTTP schemes.
  - Enforce exact origin binding for enclave/proxy (scheme, host, port), including correct defaults for 80/443; block unconfigured HTTP and foreign hosts.
  - In `tls` transport, require `base_url` to match the verified enclave origin; otherwise raise.
  - Make `base_url` Optional in `SecureClient`/`NewSecureClient` and avoid adding the enclave URL header when proxy and enclave share the same origin.

<sup>Written for commit 26c865f5f23f3d17752089c022ce49c6f3d20ec4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-python/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

