### PR TITLE
Chore: bump EHBP 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ sbom-files = ["sbom.cdx.json"]
 
 [project]
 name = "tinfoil"
-version = "0.13.5"
+version = "0.13.6"
 description = "Python client for Tinfoil"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.10"
 dependencies = [
     "openai>=1.63.0",
     "httpx>=0.28",
-    "tinfoil-ehbp>=0.2.3",
+    "tinfoil-ehbp>=0.3.0",
     "requests>=2.31.0",
     "cryptography>=42.0.0",
     "pyOpenSSL>=25.0.0",
@@ -46,3 +46,5 @@ constraint-dependencies = [
 ]
 
 [tool.uv.exclude-newer-package]
+# Allow the just-released EHBP client (first-party dependency).
+tinfoil-ehbp = "2026-07-23T00:00:00Z"

--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,11 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-07-11T00:12:56.54894Z"
+exclude-newer = "2026-07-18T22:25:22.197611Z"
 exclude-newer-span = "P4D"
+
+[options.exclude-newer-package]
+tinfoil-ehbp = "2026-07-23T00:00:00Z"
 
 [manifest]
 constraints = [{ name = "idna", specifier = ">=3.15" }]
@@ -995,7 +998,7 @@ requires-dist = [
     { name = "pyopenssl", specifier = ">=25.0.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "sigstore", specifier = ">=4.3.0" },
-    { name = "tinfoil-ehbp", specifier = ">=0.2.3" },
+    { name = "tinfoil-ehbp", specifier = ">=0.3.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
@@ -1007,16 +1010,16 @@ dev = [
 
 [[package]]
 name = "tinfoil-ehbp"
-version = "0.2.5"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
     { name = "pyhpke" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/75/1cb8cd79944f32a4e3951acc44e5c8a598174706729d4f33541d93344c9c/tinfoil_ehbp-0.2.5.tar.gz", hash = "sha256:e45dae49681f31d26bb59a9efe6a648da73b68a8bb0113c606ffbec594bb1c01", size = 15275, upload-time = "2026-07-01T17:06:59.94Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/95/aabb64b33a28a9307349624b07400b9c1e819706ff0733b8b3506aa1b76e/tinfoil_ehbp-0.3.0.tar.gz", hash = "sha256:601db7ff77fc2cc0b28943c468f58f4eb180de02ee9a41bff8a2c12e1e2403fa", size = 16199, upload-time = "2026-07-22T22:21:44.168Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/fd/c8f8891cf72fc11e2212193513484e53078a818d6b1f6e64f2840790b375/tinfoil_ehbp-0.2.5-py3-none-any.whl", hash = "sha256:ce15e194ddfdbe7a1be98c4743bb0748fbffe45fd2210d9cb7697df62473466f", size = 15092, upload-time = "2026-07-01T17:06:58.589Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/1f/ae06385b661d121118c2f1bd36f831c41b431b2dd6f60aa4bd85572b0a4e/tinfoil_ehbp-0.3.0-py3-none-any.whl", hash = "sha256:8391ebef7cb6f70240cbcd9ed54c5470bef35443744ef851024b0c6032d92182", size = 15424, upload-time = "2026-07-22T22:21:42.99Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-07-18T22:25:22.197611Z"
+exclude-newer = "2026-07-18T22:39:40.749418Z"
 exclude-newer-span = "P4D"
 
 [options.exclude-newer-package]
@@ -967,7 +967,7 @@ wheels = [
 
 [[package]]
 name = "tinfoil"
-version = "0.13.5"
+version = "0.13.6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade to `tinfoil-ehbp` 0.3.0 and release `tinfoil` 0.13.6 to pick up the latest EHBP fixes. Updates UV settings to allow the new release and refreshes the lockfile.

- **Dependencies**
  - Bump `tinfoil-ehbp` to `>=0.3.0`.
  - Set `tinfoil` version to `0.13.6`.
  - Add `tinfoil-ehbp` to `[tool.uv.exclude-newer-package]` and update `uv.lock`.

<sup>Written for commit d87eda56464edc39c393b4444ad750e7fc7ec739. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-python/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

