### PR TITLE
Expose verification provenance metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ verification completion time are available from the client:
 ```python
 document = client.get_verification_document()
 
-print(document.release_tag)
+print(document.release_tag)  # None for pinned or bundled verification
 print(document.release_digest)
 print(document.code_fingerprint)
 print(document.enclave_fingerprint)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ chat_completion = client.chat.completions.create(
 print(chat_completion.choices[0].message.content)
 ```
 
+### Inspecting verification
+
+The verified release, measurements, attested keys, verifier version, and local
+verification completion time are available from the client:
+
+```python
+document = client.get_verification_document()
+
+print(document.release_tag)
+print(document.release_digest)
+print(document.code_fingerprint)
+print(document.enclave_fingerprint)
+print(document.verifier)
+print(document.verified_at)
+```
+
+`verified_at` is recorded from the local clock after every successful
+verification or re-verification. It is not an attested evidence timestamp or a
+freshness guarantee.
+
 ### Audio Transcription with Whisper
 
 You can transcribe audio files using OpenAI's Whisper model:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ sbom-files = ["sbom.cdx.json"]
 
 [project]
 name = "tinfoil"
-version = "0.13.6"
+version = "0.14.0"
 description = "Python client for Tinfoil"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tinfoil/__init__.py
+++ b/src/tinfoil/__init__.py
@@ -145,6 +145,10 @@ class _HTTPSecureClient:
         self._tf_client.assert_request_allowed(url)
         return self._http_client.post(url, headers=headers, data=data, json=json, timeout=timeout)
 
+    def get_verification_document(self) -> Optional[VerificationDocument]:
+        """Returns the detailed verification document with per-step status"""
+        return self._tf_client.get_verification_document()
+
 
 def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model-router", measurement: Optional[dict] = None, transport: TransportMode = DEFAULT_TRANSPORT_MODE, base_url: Optional[str] = None, attestation_bundle_url: str = "", user_cache_secret: Optional[str] = None):
     """Create a secure HTTP client for direct GET/POST through the Tinfoil enclave."""

--- a/src/tinfoil/attestation/bundle.py
+++ b/src/tinfoil/attestation/bundle.py
@@ -11,6 +11,7 @@ lets attestation traffic flow through a proxy.
 import base64
 import json
 from dataclasses import dataclass
+from typing import Optional
 from urllib.parse import urlparse
 
 import requests
@@ -31,6 +32,7 @@ class Bundle:
     sigstore_bundle: bytes
     vcek: str  # base64-encoded DER
     enclave_cert: str  # PEM
+    release_tag: Optional[str] = None
 
 
 def fetch_bundle_from(
@@ -80,6 +82,7 @@ def fetch_bundle_from(
             sigstore_bundle=json.dumps(data["sigstoreBundle"]).encode(),
             vcek=data.get("vcek", ""),
             enclave_cert=data.get("enclaveCert", ""),
+            release_tag=data.get("releaseTag"),
         )
     except (KeyError, TypeError, ValueError) as e:
         raise ValueError(f"Invalid attestation bundle from {base}: {e}") from e

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -974,7 +974,7 @@ class SecureClient:
             doc.steps["fetch_digest"] = VerificationStepState(status="skipped")
             doc.steps["verify_code"] = VerificationStepState(status="success")
         except Exception as e:
-            doc.steps["fetch_digest"] = VerificationStepState(status="failed", error=str(e))
+            doc.steps["fetch_digest"] = VerificationStepState(status="skipped")
             doc.steps["verify_code"] = VerificationStepState(status="failed", error=str(e))
             _attach_verification_document(e, doc)
             raise

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import contextlib
+import copy
 import http.client
 import json
 import ssl
@@ -159,10 +160,62 @@ class VerificationDocument:
     verifier: SoftwareIdentity = field(default_factory=_verifier_identity)
     verified_at: Optional[str] = None
 
+    def to_dict(self) -> dict:
+        def measurement(value: Measurement) -> dict:
+            return {"type": value.type.value, "registers": list(value.registers)}
+
+        result = {
+            "schemaVersion": self.schema_version,
+            "configRepo": self.config_repo,
+            "enclaveHost": self.enclave_host,
+            "releaseTag": self.release_tag,
+            "releaseDigest": self.release_digest,
+            "codeMeasurement": measurement(self.code_measurement) if self.code_measurement else None,
+            "enclaveMeasurement": {
+                key: value
+                for key, value in {
+                    "measurement": measurement(self.enclave_measurement.measurement),
+                    "tlsPublicKeyFingerprint": self.enclave_measurement.public_key_fp,
+                    "hpkePublicKey": self.enclave_measurement.hpke_public_key,
+                }.items()
+                if value is not None
+            } if self.enclave_measurement else None,
+            "tlsPublicKey": self.tls_public_key,
+            "hpkePublicKey": self.hpke_public_key,
+            "hardwareMeasurement": {
+                "ID": self.hardware_measurement.id,
+                "MRTD": self.hardware_measurement.mrtd,
+                "RTMR0": self.hardware_measurement.rtmr0,
+            } if self.hardware_measurement else None,
+            "codeFingerprint": self.code_fingerprint,
+            "enclaveFingerprint": self.enclave_fingerprint,
+            "selectedRouterEndpoint": self.selected_router_endpoint,
+            "securityVerified": self.security_verified,
+            "verifier": {"name": self.verifier.name, "version": self.verifier.version},
+            "verifiedAt": self.verified_at,
+            "steps": {
+                {
+                    "fetch_digest": "fetchDigest",
+                    "verify_code": "verifyCode",
+                    "verify_enclave": "verifyEnclave",
+                    "compare_measurements": "compareMeasurements",
+                }.get(name, name): {
+                    key: value
+                    for key, value in {"status": step.status, "error": step.error}.items()
+                    if value is not None
+                }
+                for name, step in self.steps.items()
+            },
+        }
+        return {key: value for key, value in result.items() if value is not None}
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
 
 def _attach_verification_document(exc: Exception, verification_document: VerificationDocument) -> None:
     try:
-        setattr(exc, "verification_document", verification_document)
+        setattr(exc, "verification_document", copy.deepcopy(verification_document))
     except Exception:
         pass
 
@@ -595,7 +648,7 @@ class SecureClient:
 
     def get_verification_document(self) -> Optional[VerificationDocument]:
         """Returns the detailed verification document from the last verify() call"""
-        return self._verification_document
+        return copy.deepcopy(self._verification_document)
 
     def _create_socket_wrapper(self, expected_fp: str):
         """
@@ -862,7 +915,6 @@ class SecureClient:
             try:
                 release = fetch_latest_release(self.repo)
                 digest = release.digest
-                doc.release_tag = release.tag
                 doc.release_digest = release.digest
                 doc.steps["fetch_digest"] = VerificationStepState(status="success")
             except Exception as e:
@@ -873,7 +925,10 @@ class SecureClient:
             # Step 3: Verify code via Sigstore
             try:
                 sigstore_bundle = fetch_attestation_bundle(self.repo, digest)
-                code_measurements = verify_attestation(sigstore_bundle, digest, self.repo)
+                code_measurements = verify_attestation(
+                    sigstore_bundle, digest, self.repo, release.tag
+                )
+                doc.release_tag = release.tag
                 doc.code_measurement = code_measurements
                 doc.code_fingerprint = code_measurements.fingerprint()
                 doc.steps["verify_code"] = VerificationStepState(status="success")
@@ -909,11 +964,14 @@ class SecureClient:
 
         # Step 1: Verify code measurement from the bundled Sigstore bundle
         try:
-            code_measurements = verify_attestation(bundle.sigstore_bundle, bundle.digest, self.repo)
+            code_measurements = verify_attestation(
+                bundle.sigstore_bundle, bundle.digest, self.repo, bundle.release_tag
+            )
             doc.release_digest = bundle.digest
+            doc.release_tag = bundle.release_tag
             doc.code_measurement = code_measurements
             doc.code_fingerprint = code_measurements.fingerprint()
-            doc.steps["fetch_digest"] = VerificationStepState(status="success")
+            doc.steps["fetch_digest"] = VerificationStepState(status="skipped")
             doc.steps["verify_code"] = VerificationStepState(status="success")
         except Exception as e:
             doc.steps["fetch_digest"] = VerificationStepState(status="failed", error=str(e))

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -15,6 +15,8 @@ from urllib.parse import urlparse, urlencode
 import cryptography.x509
 from cryptography.hazmat.primitives.serialization import PublicFormat, Encoding
 import hashlib
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
 
 from ehbp import (
     AsyncEHBPTransport,
@@ -31,7 +33,7 @@ from .attestation import (
 )
 from .attestation.attestation_tdx import verify_tdx_hardware
 from .attestation.types import Measurement, HardwareMeasurement, Verification
-from .github import fetch_latest_digest, fetch_attestation_bundle
+from .github import fetch_latest_release, fetch_attestation_bundle
 from .sigstore import verify_attestation, fetch_latest_hardware_measurements
 from .user_cache_secret import (
     resolve_user_cache_secret,
@@ -113,6 +115,24 @@ class VerificationStepState:
     error: Optional[str] = None
 
 
+@dataclass(frozen=True)
+class SoftwareIdentity:
+    name: str
+    version: str
+
+
+def _verifier_identity() -> SoftwareIdentity:
+    try:
+        package_version = version("tinfoil")
+    except PackageNotFoundError:
+        package_version = "unknown"
+    return SoftwareIdentity(name="tinfoil", version=package_version)
+
+
+def _verified_at_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
 @dataclass
 class VerificationDocument:
     """Captures the full result and per-step status of enclave verification"""
@@ -134,6 +154,10 @@ class VerificationDocument:
         "verify_enclave": VerificationStepState(status="pending"),
         "compare_measurements": VerificationStepState(status="pending"),
     })
+    schema_version: int = 1
+    release_tag: str = ""
+    verifier: SoftwareIdentity = field(default_factory=_verifier_identity)
+    verified_at: Optional[str] = None
 
 
 def _attach_verification_document(exc: Exception, verification_document: VerificationDocument) -> None:
@@ -801,6 +825,11 @@ class SecureClient:
                 if actual_measurement != expected_snp_measurement:
                     raise ValueError(f"SNP measurement mismatch: expected {expected_snp_measurement}, got {actual_measurement}")
                 doc.steps["compare_measurements"] = VerificationStepState(status="success")
+                doc.code_measurement = Measurement(
+                    type=verification.measurement.type,
+                    registers=[expected_snp_measurement],
+                )
+                doc.code_fingerprint = doc.code_measurement.fingerprint()
             except Exception as e:
                 doc.steps["compare_measurements"] = VerificationStepState(status="failed", error=str(e))
                 _attach_verification_document(e, doc)
@@ -808,6 +837,7 @@ class SecureClient:
 
             doc.release_digest = "pinned_no_digest"
             doc.security_verified = True
+            doc.verified_at = _verified_at_now()
             self._ground_truth = GroundTruth(
                 public_key=verification.public_key_fp,
                 digest="pinned_no_digest",
@@ -820,8 +850,10 @@ class SecureClient:
 
             # Step 2: Fetch release digest
             try:
-                digest = fetch_latest_digest(self.repo)
-                doc.release_digest = digest
+                release = fetch_latest_release(self.repo)
+                digest = release.digest
+                doc.release_tag = release.tag
+                doc.release_digest = release.digest
                 doc.steps["fetch_digest"] = VerificationStepState(status="success")
             except Exception as e:
                 doc.steps["fetch_digest"] = VerificationStepState(status="failed", error=str(e))
@@ -850,6 +882,7 @@ class SecureClient:
                 raise
 
             doc.security_verified = True
+            doc.verified_at = _verified_at_now()
             self._ground_truth = GroundTruth(
                 public_key=verification.public_key_fp,
                 digest=digest,
@@ -932,6 +965,7 @@ class SecureClient:
         # Attestation came from the bundle; adopt its domain as the enclave host.
         self.enclave = bundle.domain
         doc.security_verified = True
+        doc.verified_at = _verified_at_now()
         self._ground_truth = GroundTruth(
             public_key=verification.public_key_fp,
             digest=bundle.digest,

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -155,7 +155,7 @@ class VerificationDocument:
         "compare_measurements": VerificationStepState(status="pending"),
     })
     schema_version: int = 1
-    release_tag: str = ""
+    release_tag: Optional[str] = None
     verifier: SoftwareIdentity = field(default_factory=_verifier_identity)
     verified_at: Optional[str] = None
 
@@ -767,6 +767,23 @@ class SecureClient:
         transport = self._wrap_async_transport(transport)
         return httpx.AsyncClient(transport=transport, follow_redirects=False)
 
+    def _finalize_verification(
+        self,
+        doc: VerificationDocument,
+        verification: Verification,
+        digest: str,
+    ) -> GroundTruth:
+        doc.release_digest = digest
+        doc.security_verified = True
+        doc.verified_at = _verified_at_now()
+        self._ground_truth = GroundTruth(
+            public_key=verification.public_key_fp,
+            digest=digest,
+            measurement=verification.measurement,
+            hpke_public_key=verification.hpke_public_key or "",
+        )
+        return self._ground_truth
+
     def verify(self) -> GroundTruth:
         """
         Fetches the latest verification information from GitHub and Sigstore
@@ -835,16 +852,9 @@ class SecureClient:
                 _attach_verification_document(e, doc)
                 raise
 
-            doc.release_digest = "pinned_no_digest"
-            doc.security_verified = True
-            doc.verified_at = _verified_at_now()
-            self._ground_truth = GroundTruth(
-                public_key=verification.public_key_fp,
-                digest="pinned_no_digest",
-                measurement=verification.measurement,
-                hpke_public_key=verification.hpke_public_key or "",
+            return self._finalize_verification(
+                doc, verification, "pinned_no_digest"
             )
-            return self._ground_truth
         else:
             # GitHub-based verification
 
@@ -881,15 +891,7 @@ class SecureClient:
                 _attach_verification_document(e, doc)
                 raise
 
-            doc.security_verified = True
-            doc.verified_at = _verified_at_now()
-            self._ground_truth = GroundTruth(
-                public_key=verification.public_key_fp,
-                digest=digest,
-                measurement=verification.measurement,
-                hpke_public_key=verification.hpke_public_key or "",
-            )
-            return self._ground_truth
+            return self._finalize_verification(doc, verification, digest)
 
     def verify_from_bundle(self, bundle: Bundle) -> GroundTruth:
         """
@@ -964,15 +966,7 @@ class SecureClient:
 
         # Attestation came from the bundle; adopt its domain as the enclave host.
         self.enclave = bundle.domain
-        doc.security_verified = True
-        doc.verified_at = _verified_at_now()
-        self._ground_truth = GroundTruth(
-            public_key=verification.public_key_fp,
-            digest=bundle.digest,
-            measurement=verification.measurement,
-            hpke_public_key=verification.hpke_public_key or "",
-        )
-        return self._ground_truth
+        return self._finalize_verification(doc, verification, bundle.digest)
 
     def get_http_client(self) -> urllib.request.OpenerDirector:
         """

--- a/src/tinfoil/github.py
+++ b/src/tinfoil/github.py
@@ -5,8 +5,15 @@ from typing import Dict, Any
 import os
 import platformdirs
 import sys
+from dataclasses import dataclass
 
 GITHUB_PROXY = "https://github-proxy.tinfoil.sh"
+
+
+@dataclass(frozen=True)
+class Release:
+    tag: str
+    digest: str
 
 # --- Cache Setup ---
 _GITHUB_CACHE_DIR = platformdirs.user_cache_dir("tinfoil", "tinfoil")
@@ -27,7 +34,7 @@ def _attestation_bundle_cache_path(repo: str, digest: str) -> str:
     return os.path.join(_GITHUB_CACHE_DIR, filename)
 # --- End Cache Setup ---
 
-def fetch_latest_digest(repo: str) -> str:
+def fetch_latest_release(repo: str) -> Release:
     """
     Gets the latest release and attestation digest of a repo.
     
@@ -35,7 +42,7 @@ def fetch_latest_digest(repo: str) -> str:
         repo: The GitHub repository in format "owner/repo"
         
     Returns:
-        The digest string
+        The selected release tag and digest
         
     Raises:
         Exception: If there's any error fetching or parsing the data
@@ -54,20 +61,25 @@ def fetch_latest_digest(repo: str) -> str:
     eif_regex = re.compile(r'EIF hash: ([a-fA-F0-9]{64})')
     matches = eif_regex.search(body)
     if matches:
-        return matches.group(1)
+        return Release(tag=tag_name, digest=matches.group(1))
     
     # Other format to fetch Digest
     digest_regex = re.compile(r'Digest: `([a-fA-F0-9]{64})`')
     matches = digest_regex.search(body)
     if matches:
-        return matches.group(1)
+        return Release(tag=tag_name, digest=matches.group(1))
     
     # Fallback option: fetch digest from github special endpoint
     digest_url = f"{GITHUB_PROXY}/{repo}/releases/download/{tag_name}/tinfoil.hash"
     response = requests.get(digest_url, timeout=15)
     if response.status_code != 200:
         raise Exception(f"Failed to fetch attestation digest: {response.status_code} {response.reason}")
-    return response.text.strip()
+    return Release(tag=tag_name, digest=response.text.strip())
+
+
+def fetch_latest_digest(repo: str) -> str:
+    """Gets the attestation digest of the latest release of a repo."""
+    return fetch_latest_release(repo).digest
 
 def fetch_attestation_bundle(repo: str, digest: str) -> bytes:
     """

--- a/src/tinfoil/sigstore.py
+++ b/src/tinfoil/sigstore.py
@@ -6,7 +6,7 @@ from cryptography.x509 import PrecertificateSignedCertificateTimestamps
 import json
 import re
 
-from typing import List
+from typing import List, Optional
 from .attestation import Measurement, PredicateType, HardwareMeasurement
 from .github import fetch_latest_digest, fetch_attestation_bundle
 
@@ -130,7 +130,9 @@ class GitHubWorkflowRefPattern:
             )
 
 
-def _verify_dsse_bundle(bundle_json: bytes, digest: str, repo: str) -> dict:
+def _verify_dsse_bundle(
+    bundle_json: bytes, digest: str, repo: str, expected_release_tag: Optional[str] = None
+) -> dict:
     """
     Verify a Sigstore DSSE bundle and return the parsed in-toto payload.
 
@@ -141,6 +143,7 @@ def _verify_dsse_bundle(bundle_json: bytes, digest: str, repo: str) -> dict:
         bundle_json: Raw Sigstore bundle JSON
         digest: Expected SHA256 hex digest of the DSSE payload subject
         repo: GitHub repository (e.g. "tinfoilsh/confidential-router")
+        expected_release_tag: Release tag that must exactly match the signed workflow ref
 
     Returns:
         Parsed in-toto statement dict with predicateType, predicate, subject, etc.
@@ -158,10 +161,15 @@ def _verify_dsse_bundle(bundle_json: bytes, digest: str, repo: str) -> dict:
     # SPEC §5.2: reject duplicate-log SCTs before signature/SCT verification.
     reject_duplicate_sct_logs(bundle)
 
+    workflow_ref_pattern = (
+        rf"^refs/tags/{re.escape(expected_release_tag)}\Z"
+        if expected_release_tag is not None
+        else r"^refs/tags/.+\Z"
+    )
     policy = AllOf([
         OIDCIssuerV2Preferred(OIDC_ISSUER),
         GitHubWorkflowRepository(repo),
-        GitHubWorkflowRefPattern("refs/tags/.*")
+        GitHubWorkflowRefPattern(workflow_ref_pattern)
     ])
 
     payload_type, payload_bytes = verifier.verify_dsse(bundle, policy)
@@ -185,7 +193,9 @@ def _verify_dsse_bundle(bundle_json: bytes, digest: str, repo: str) -> dict:
     return statement
 
 
-def verify_attestation(bundle_json: bytes, digest: str, repo: str) -> Measurement:
+def verify_attestation(
+    bundle_json: bytes, digest: str, repo: str, expected_release_tag: Optional[str] = None
+) -> Measurement:
     """
     Verifies the attested measurements of an enclave image against a trusted root (Sigstore)
     and returns the measurement payload contained in the DSSE.
@@ -202,7 +212,7 @@ def verify_attestation(bundle_json: bytes, digest: str, repo: str) -> Measuremen
         ValueError: If verification fails or digests don't match
     """
     try:
-        statement = _verify_dsse_bundle(bundle_json, digest, repo)
+        statement = _verify_dsse_bundle(bundle_json, digest, repo, expected_release_tag)
 
         predicate_type = PredicateType(statement["predicateType"])
         predicate_fields = statement["predicate"]

--- a/tests/test_verification_document.py
+++ b/tests/test_verification_document.py
@@ -1,0 +1,244 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sigstore.errors import VerificationError
+
+from tinfoil.attestation import Bundle, Document
+from tinfoil.attestation.bundle import fetch_bundle_from
+from tinfoil.attestation.types import (
+    HardwareMeasurement,
+    Measurement,
+    PredicateType,
+    Verification,
+)
+from tinfoil.client import SecureClient, SoftwareIdentity, VerificationDocument
+from tinfoil.github import Release
+from tinfoil.sigstore import _verify_dsse_bundle
+
+
+def _measurement() -> Measurement:
+    return Measurement(type=PredicateType.SEV_GUEST_V2, registers=["measurement"])
+
+
+def _verification() -> Verification:
+    return Verification(
+        measurement=_measurement(),
+        public_key_fp="tls-fingerprint",
+        hpke_public_key="hpke-key",
+    )
+
+
+def test_direct_verification_binds_and_reports_selected_release_tag():
+    attestation = MagicMock()
+    attestation.verify.return_value = _verification()
+    code_measurement = _measurement()
+    client = SecureClient(enclave="enclave.test", repo="org/repo")
+
+    with (
+        patch("tinfoil.client.fetch_attestation", return_value=attestation),
+        patch(
+            "tinfoil.client.fetch_latest_release",
+            return_value=Release(tag="v1.2.3", digest="digest"),
+        ),
+        patch("tinfoil.client.fetch_attestation_bundle", return_value=b"bundle"),
+        patch(
+            "tinfoil.client.verify_attestation", return_value=code_measurement
+        ) as verify_code,
+    ):
+        client.verify()
+
+    verify_code.assert_called_once_with(b"bundle", "digest", "org/repo", "v1.2.3")
+    assert client.get_verification_document().release_tag == "v1.2.3"
+
+
+def test_bundle_release_tag_is_reported_only_after_exact_verification():
+    report = Document(format=PredicateType.SEV_GUEST_V2, body="Zm9v")
+    bundle = Bundle(
+        domain="enclave.test",
+        enclave_attestation_report=report,
+        digest="digest",
+        sigstore_bundle=b"bundle",
+        vcek="",
+        enclave_cert="certificate",
+        release_tag="v1.2.3",
+    )
+    client = SecureClient(repo="org/repo", attestation_bundle_url="https://atc.test")
+
+    with patch(
+        "tinfoil.client.verify_attestation",
+        side_effect=VerificationError("tag mismatch"),
+    ) as verify_code:
+        with pytest.raises(VerificationError, match="tag mismatch"):
+            client.verify_from_bundle(bundle)
+
+    verify_code.assert_called_once_with(b"bundle", "digest", "org/repo", "v1.2.3")
+    assert client.get_verification_document().release_tag is None
+
+
+def test_fetched_bundle_preserves_optional_release_tag():
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {
+        "domain": "enclave.test",
+        "enclaveAttestationReport": {
+            "format": PredicateType.SEV_GUEST_V2.value,
+            "body": "Zm9v",
+        },
+        "digest": "digest",
+        "releaseTag": "v1.2.3",
+        "sigstoreBundle": {},
+    }
+
+    with patch("tinfoil.attestation.bundle.requests.get", return_value=response):
+        bundle = fetch_bundle_from("https://atc.test")
+
+    assert bundle.release_tag == "v1.2.3"
+
+
+def test_bundle_reports_exactly_verified_release_tag():
+    report = Document(format=PredicateType.SEV_GUEST_V2, body="Zm9v")
+    bundle = Bundle(
+        domain="enclave.test",
+        enclave_attestation_report=report,
+        digest="digest",
+        sigstore_bundle=b"bundle",
+        vcek="",
+        enclave_cert="certificate",
+        release_tag="v1.2.3",
+    )
+    client = SecureClient(repo="org/repo", attestation_bundle_url="https://atc.test")
+
+    with (
+        patch.object(report, "verify", return_value=_verification()),
+        patch("tinfoil.client.verify_attestation", return_value=_measurement()),
+        patch("tinfoil.client.verify_certificate"),
+    ):
+        client.verify_from_bundle(bundle)
+
+    assert client.get_verification_document().release_tag == "v1.2.3"
+
+
+def test_sigstore_rejects_a_different_exact_workflow_tag():
+    certificate = MagicMock()
+    certificate.extensions.get_extension_for_oid.return_value.value.value = (
+        b"refs/tags/v1.2.4"
+    )
+    verifier = MagicMock()
+
+    def verify_dsse(_bundle, policy):
+        policy._children[-1].verify(certificate)
+
+    verifier.verify_dsse.side_effect = verify_dsse
+
+    with (
+        patch("tinfoil.sigstore.Verifier.production", return_value=verifier),
+        patch("tinfoil.sigstore.Bundle.from_json", return_value=MagicMock()),
+        patch("tinfoil.sigstore.reject_duplicate_sct_logs"),
+    ):
+        with pytest.raises(VerificationError, match="does not match pattern"):
+            _verify_dsse_bundle(b"{}", "digest", "org/repo", "v1.2.3")
+
+
+def test_sigstore_rejects_a_workflow_tag_with_trailing_newline():
+    certificate = MagicMock()
+    certificate.extensions.get_extension_for_oid.return_value.value.value = (
+        b"refs/tags/v1.2.3\n"
+    )
+    verifier = MagicMock()
+
+    def verify_dsse(_bundle, policy):
+        policy._children[-1].verify(certificate)
+
+    verifier.verify_dsse.side_effect = verify_dsse
+
+    with (
+        patch("tinfoil.sigstore.Verifier.production", return_value=verifier),
+        patch("tinfoil.sigstore.Bundle.from_json", return_value=MagicMock()),
+        patch("tinfoil.sigstore.reject_duplicate_sct_logs"),
+    ):
+        with pytest.raises(VerificationError, match="does not match pattern"):
+            _verify_dsse_bundle(b"{}", "digest", "org/repo", "v1.2.3")
+
+
+def test_get_verification_document_returns_an_isolated_copy():
+    client = SecureClient(enclave="enclave.test", repo="org/repo")
+    client._verification_document = VerificationDocument(release_tag="v1.2.3")
+
+    returned = client.get_verification_document()
+    returned.release_tag = "forged"
+    returned.steps["verify_code"].status = "failed"
+
+    unchanged = client.get_verification_document()
+    assert unchanged.release_tag == "v1.2.3"
+    assert unchanged.steps["verify_code"].status == "pending"
+
+
+def test_failure_exception_document_cannot_mutate_client_state():
+    client = SecureClient(enclave="enclave.test", repo="org/repo")
+    attestation = MagicMock()
+    attestation.verify.side_effect = ValueError("verification failed")
+
+    with patch("tinfoil.client.fetch_attestation", return_value=attestation):
+        with pytest.raises(ValueError) as exc_info:
+            client.verify()
+
+    getattr(exc_info.value, "verification_document").steps[
+        "verify_enclave"
+    ].status = "success"
+
+    assert client.get_verification_document().steps["verify_enclave"].status == "failed"
+
+
+def test_verification_document_serializes_to_shared_camel_case_schema():
+    measurement = _measurement()
+    document = VerificationDocument(
+        config_repo="org/repo",
+        enclave_host="enclave.test",
+        release_digest="digest",
+        release_tag="v1.2.3",
+        code_measurement=measurement,
+        enclave_measurement=_verification(),
+        tls_public_key="tls-fingerprint",
+        hpke_public_key="hpke-key",
+        hardware_measurement=HardwareMeasurement(
+            id="platform@digest", mrtd="mrtd", rtmr0="rtmr0"
+        ),
+        code_fingerprint="code-fingerprint",
+        enclave_fingerprint="enclave-fingerprint",
+        selected_router_endpoint="router.test",
+        security_verified=True,
+        verifier=SoftwareIdentity(name="tinfoil", version="0.14.0"),
+        verified_at="2026-08-04T12:00:00Z",
+    )
+
+    serialized = document.to_dict()
+
+    assert serialized["schemaVersion"] == 1
+    assert serialized["releaseTag"] == "v1.2.3"
+    assert serialized["codeMeasurement"] == {
+        "type": PredicateType.SEV_GUEST_V2.value,
+        "registers": ["measurement"],
+    }
+    assert serialized["enclaveMeasurement"] == {
+        "measurement": serialized["codeMeasurement"],
+        "tlsPublicKeyFingerprint": "tls-fingerprint",
+        "hpkePublicKey": "hpke-key",
+    }
+    assert serialized["hardwareMeasurement"] == {
+        "ID": "platform@digest",
+        "MRTD": "mrtd",
+        "RTMR0": "rtmr0",
+    }
+    assert serialized["steps"]["compareMeasurements"] == {"status": "pending"}
+    assert "verified_at" not in serialized
+    assert json.loads(document.to_json()) == serialized
+
+
+def test_verification_document_serialization_omits_none_values():
+    serialized = VerificationDocument().to_dict()
+
+    assert "releaseTag" not in serialized
+    assert "codeMeasurement" not in serialized
+    assert "hardwareMeasurement" not in serialized
+    assert "verifiedAt" not in serialized

--- a/tests/test_verification_document.py
+++ b/tests/test_verification_document.py
@@ -231,7 +231,7 @@ def test_verification_document_serializes_to_shared_camel_case_schema():
         "RTMR0": "rtmr0",
     }
     assert serialized["steps"]["compareMeasurements"] == {"status": "pending"}
-    assert "verified_at" not in serialized
+    assert serialized["verifiedAt"] == "2026-08-04T12:00:00Z"
     assert json.loads(document.to_json()) == serialized
 
 

--- a/tests/test_verification_failures.py
+++ b/tests/test_verification_failures.py
@@ -147,7 +147,9 @@ class TestSecureClientVerificationFailures:
         assert verification_document is not None
         assert verification_document.steps["verify_enclave"].status == "failed"
         assert verification_document.steps["verify_enclave"].error == "TDX attestation verification failed"
-        assert getattr(exc_info.value, "verification_document", None) is verification_document
+        attached_document = getattr(exc_info.value, "verification_document", None)
+        assert attached_document is not None
+        assert attached_document is not verification_document
 
     @patch('tinfoil.client.fetch_attestation')
     @patch('tinfoil.client.fetch_latest_release')
@@ -307,7 +309,9 @@ class TestDirectMeasurementVerification:
         assert verification_document.steps["fetch_digest"].status == "skipped"
         assert verification_document.steps["verify_code"].status == "skipped"
         assert verification_document.steps["compare_measurements"].status == "failed"
-        assert getattr(exc_info.value, "verification_document", None) is verification_document
+        attached_document = getattr(exc_info.value, "verification_document", None)
+        assert attached_document is not None
+        assert attached_document is not verification_document
 
 
 class TestVerifyPeerFingerprint:

--- a/tests/test_verification_failures.py
+++ b/tests/test_verification_failures.py
@@ -150,6 +150,7 @@ class TestSecureClientVerificationFailures:
         attached_document = getattr(exc_info.value, "verification_document", None)
         assert attached_document is not None
         assert attached_document is not verification_document
+        assert attached_document.to_dict() == verification_document.to_dict()
 
     @patch('tinfoil.client.fetch_attestation')
     @patch('tinfoil.client.fetch_latest_release')
@@ -291,6 +292,8 @@ class TestDirectMeasurementVerification:
         )
         mock_verification = MagicMock()
         mock_verification.measurement = runtime_measurement
+        mock_verification.public_key_fp = "tls-fingerprint"
+        mock_verification.hpke_public_key = "hpke-key"
         mock_doc = MagicMock()
         mock_doc.verify.return_value = mock_verification
         mock_fetch.return_value = mock_doc
@@ -312,6 +315,7 @@ class TestDirectMeasurementVerification:
         attached_document = getattr(exc_info.value, "verification_document", None)
         assert attached_document is not None
         assert attached_document is not verification_document
+        assert attached_document.to_dict() == verification_document.to_dict()
 
 
 class TestVerifyPeerFingerprint:

--- a/tests/test_verification_failures.py
+++ b/tests/test_verification_failures.py
@@ -16,6 +16,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from tinfoil.client import SecureClient, _verify_peer_fingerprint
+from tinfoil.github import Release
 from tinfoil.attestation import (
     Measurement,
     PredicateType,
@@ -149,7 +150,7 @@ class TestSecureClientVerificationFailures:
         assert getattr(exc_info.value, "verification_document", None) is verification_document
 
     @patch('tinfoil.client.fetch_attestation')
-    @patch('tinfoil.client.fetch_latest_digest')
+    @patch('tinfoil.client.fetch_latest_release')
     @patch('tinfoil.client.fetch_attestation_bundle')
     @patch('tinfoil.client.verify_attestation')
     def test_measurement_mismatch_blocks_verify(
@@ -157,7 +158,7 @@ class TestSecureClientVerificationFailures:
     ):
         """If code measurements don't match runtime, verify() must raise."""
         # Setup mocks
-        mock_fetch_digest.return_value = "test_digest"
+        mock_fetch_digest.return_value = Release(tag="v1.2.3", digest="test_digest")
         mock_fetch_bundle.return_value = {}
 
         # Runtime measurement from enclave
@@ -184,7 +185,7 @@ class TestSecureClientVerificationFailures:
             client.verify()
 
     @patch('tinfoil.client.fetch_attestation')
-    @patch('tinfoil.client.fetch_latest_digest')
+    @patch('tinfoil.client.fetch_latest_release')
     @patch('tinfoil.client.fetch_attestation_bundle')
     @patch('tinfoil.client.verify_attestation')
     @patch('tinfoil.client.fetch_latest_hardware_measurements')
@@ -195,7 +196,7 @@ class TestSecureClientVerificationFailures:
     ):
         """If TDX hardware measurements don't match, verify() must raise."""
         # Setup mocks
-        mock_fetch_digest.return_value = "test_digest"
+        mock_fetch_digest.return_value = Release(tag="v1.2.3", digest="test_digest")
         mock_fetch_bundle.return_value = {}
 
         # TDX runtime measurement from enclave

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-07-31T15:19:25.311574Z"
+exclude-newer = "2026-07-23T14:59:32.558567Z"
 exclude-newer-span = "P4D"
 
 [options.exclude-newer-package]

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-07-23T14:59:32.558567Z"
+exclude-newer = "2026-07-31T15:19:25.311574Z"
 exclude-newer-span = "P4D"
 
 [options.exclude-newer-package]
@@ -964,7 +964,7 @@ wheels = [
 
 [[package]]
 name = "tinfoil"
-version = "0.13.6"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
- add release identity, verifier identity, and successful verification time to verification documents
- expose documents consistently from low-level secure clients
- bump the Python SDK to 0.14.0

## Testing
- `python -m pytest -m \"not integration\"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds verification provenance to `tinfoil` verification documents, binds the exact GitHub release tag through Sigstore and bundle paths, and exposes the document via the client. Also switches to `fetch_latest_release`, centralizes finalization with a local `verified_at`, and serializes the document to a stable camelCase schema.

- **New Features**
  - Add `SecureClient.get_verification_document()` (also on the wrapper) and `VerificationDocument.to_dict()/to_json()` with camelCase fields.
  - Bind the exact release tag end-to-end (GitHub → Sigstore → bundles); persist `release_tag` from both sources and mark `fetchDigest` as skipped for bundled verification to align step states.
  - Replace `fetch_latest_digest` with `fetch_latest_release` to capture tag/digest; record `verified_at`; include code measurement and fingerprint for SNP‑pinned verification; return deep copies of verification docs to avoid mutation.

- **Dependencies**
  - Bump `tinfoil` version to `0.14.0`.

<sup>Written for commit ad80ebca1172c119fbc95adeafc277d7a3496a18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-python/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

