### PR TITLE
Refresh matching EHBP endpoint, key, and proxy route

### DIFF
--- a/src/tinfoil/__init__.py
+++ b/src/tinfoil/__init__.py
@@ -10,7 +10,6 @@ from .client import (
     SecureClient,
     TransportMode,
     VerificationDocument,
-    get_router_address,
 )
 
 class TinfoilAI:
@@ -38,12 +37,6 @@ class TinfoilAI:
         # Ensure at least one verification method is provided
         if measurement is None and (repo == "" or repo is None):
             raise ValueError("Must provide either 'measurement' or 'repo' parameter for verification.")
-
-        # If enclave is empty, fetch a random one from the routers API. When
-        # attesting from a bundle, the enclave host comes from the verified
-        # bundle, so no router lookup is needed.
-        if (enclave == "" or enclave is None) and not attestation_bundle_url:
-            enclave = get_router_address()
 
         self.api_key = api_key
         self._secure_client = SecureClient(enclave, repo, measurement, transport=transport, base_url=base_url, attestation_bundle_url=attestation_bundle_url, user_cache_secret=user_cache_secret)
@@ -93,12 +86,6 @@ class AsyncTinfoilAI:
         # Ensure at least one verification method is provided
         if measurement is None and (repo == "" or repo is None):
             raise ValueError("Must provide either 'measurement' or 'repo' parameter for verification.")
-
-        # If enclave is empty, fetch a random one from the routers API. When
-        # attesting from a bundle, the enclave host comes from the verified
-        # bundle, so no router lookup is needed.
-        if (enclave == "" or enclave is None) and not attestation_bundle_url:
-            enclave = get_router_address()
 
         self.api_key = api_key
         # verifier client remains sync; only used to fetch the expected public key
@@ -158,11 +145,6 @@ def NewSecureClient(enclave: str = "", repo: str = "tinfoilsh/confidential-model
     # Ensure at least one verification method is provided
     if measurement is None and (repo == "" or repo is None):
         raise ValueError("Must provide either 'measurement' or 'repo' parameter for verification.")
-
-    # If enclave is empty, fetch a random one from the routers API. When
-    # attesting from a bundle, the enclave host comes from the verified bundle.
-    if (enclave == "" or enclave is None) and not attestation_bundle_url:
-        enclave = get_router_address()
 
     tf_client = SecureClient(enclave, repo, measurement, transport=transport, base_url=base_url, attestation_bundle_url=attestation_bundle_url, user_cache_secret=user_cache_secret)
     return _HTTPSecureClient(tf_client.enclave, tf_client)

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -1013,23 +1013,31 @@ class SecureClient:
         report, release digest, Sigstore bundle, AMD VCEK, and enclave TLS
         certificate, so verification needs no direct connection to the enclave.
         """
-        constrained_enclave = expected_enclave or self._configured_enclave
-        if (
-            constrained_enclave
-            and bundle.domain.casefold().rstrip(".")
-            != constrained_enclave.casefold().rstrip(".")
-        ):
-            raise ValueError(
-                f"attestation bundle domain {bundle.domain!r} does not match "
-                f"configured enclave {constrained_enclave!r}"
-            )
-
         doc = VerificationDocument(
             config_repo=self.repo or "",
             enclave_host=bundle.domain,
             selected_router_endpoint=bundle.domain,
         )
         self._verification_document = doc
+
+        # A constructor enclave is a caller-supplied trust constraint and must
+        # never be weakened by a retry-time expectation. The latter only binds
+        # bundle recovery when the client itself was not explicitly pinned.
+        constrained_enclave = self._configured_enclave or expected_enclave
+        if (
+            constrained_enclave
+            and bundle.domain.casefold().rstrip(".")
+            != constrained_enclave.casefold().rstrip(".")
+        ):
+            exc = ValueError(
+                f"attestation bundle domain {bundle.domain!r} does not match "
+                f"configured enclave {constrained_enclave!r}"
+            )
+            doc.steps["verify_enclave"] = VerificationStepState(
+                status="failed", error=str(exc)
+            )
+            _attach_verification_document(exc, doc)
+            raise exc
 
         # Step 1: Verify code measurement from the bundled Sigstore bundle
         try:

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -417,12 +417,13 @@ class _EHBPReVerifyingTransport(httpx.BaseTransport):
         # generation. Reading a single tuple prevents a concurrent, later
         # rotation from pairing this generation's key with another endpoint.
         self._state = (inner, secure_client.enclave)
+        self._base_url = secure_client.base_url
         self._lock = threading.Lock()
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         state = self._state
         inner, enclave = state
-        _update_enclave_header(request, self._secure_client, enclave)
+        _update_enclave_header(request, self._base_url, enclave)
         try:
             return inner.handle_request(request)
         except KeyConfigMismatchError:
@@ -448,7 +449,7 @@ class _EHBPReVerifyingTransport(httpx.BaseTransport):
 
             assert retry_state is not None
             retry_inner, retry_enclave = retry_state
-            _update_enclave_header(request, self._secure_client, retry_enclave)
+            _update_enclave_header(request, self._base_url, retry_enclave)
             try:
                 return retry_inner.handle_request(request)
             finally:
@@ -466,12 +467,13 @@ class _AsyncEHBPReVerifyingTransport(httpx.AsyncBaseTransport):
     def __init__(self, secure_client: "SecureClient", inner: httpx.AsyncBaseTransport):
         self._secure_client = secure_client
         self._state = (inner, secure_client.enclave)
+        self._base_url = secure_client.base_url
         self._lock = asyncio.Lock()
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         state = self._state
         inner, enclave = state
-        _update_enclave_header(request, self._secure_client, enclave)
+        _update_enclave_header(request, self._base_url, enclave)
         try:
             return await inner.handle_async_request(request)
         except KeyConfigMismatchError:
@@ -496,7 +498,7 @@ class _AsyncEHBPReVerifyingTransport(httpx.AsyncBaseTransport):
 
             assert retry_state is not None
             retry_inner, retry_enclave = retry_state
-            _update_enclave_header(request, self._secure_client, retry_enclave)
+            _update_enclave_header(request, self._base_url, retry_enclave)
             try:
                 return await retry_inner.handle_async_request(request)
             finally:
@@ -524,56 +526,15 @@ def _enclave_url_header(base_url: str, enclave: str) -> tuple[str, bool]:
 
 def _update_enclave_header(
     request: httpx.Request,
-    client: "SecureClient",
-    enclave: Optional[str] = None,
+    base_url: str,
+    enclave: str,
 ) -> None:
     """Bind a request to the endpoint paired with its sealing transport."""
-    value, inject = _enclave_url_header(
-        client.base_url,
-        client.enclave if enclave is None else enclave,
-    )
+    value, inject = _enclave_url_header(base_url, enclave)
     if inject:
         request.headers[ENCLAVE_URL_HEADER] = value
     else:
         request.headers.pop(ENCLAVE_URL_HEADER, None)
-
-
-class _EnclaveURLHeaderTransport(httpx.BaseTransport):
-    """
-    Injects the X-Tinfoil-Enclave-Url header before delegating to the wrapped
-    transport. EHBP leaves request headers in plaintext, so the header reaches
-    the proxy while the body stays sealed to the enclave's HPKE key.
-
-    The header is recomputed for every request from the client's current
-    enclave, so it stays correct after a re-verification swaps in a different
-    enclave (for example when attesting from a bundle behind a proxy).
-    """
-
-    def __init__(self, inner: httpx.BaseTransport, client: "SecureClient"):
-        self._inner = inner
-        self._client = client
-
-    def handle_request(self, request: httpx.Request) -> httpx.Response:
-        _update_enclave_header(request, self._client)
-        return self._inner.handle_request(request)
-
-    def close(self) -> None:
-        self._inner.close()
-
-
-class _AsyncEnclaveURLHeaderTransport(httpx.AsyncBaseTransport):
-    """Async counterpart of _EnclaveURLHeaderTransport."""
-
-    def __init__(self, inner: httpx.AsyncBaseTransport, client: "SecureClient"):
-        self._inner = inner
-        self._client = client
-
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        _update_enclave_header(request, self._client)
-        return await self._inner.handle_async_request(request)
-
-    async def aclose(self) -> None:
-        await self._inner.aclose()
 
 
 class _HostBoundTransport(httpx.BaseTransport):

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -47,7 +47,6 @@ from .user_cache_secret import (
 ENCLAVE_URL_HEADER = "X-Tinfoil-Enclave-Url"
 
 DEFAULT_CONFIG_REPO = "tinfoilsh/confidential-model-router"
-DEFAULT_INFERENCE_HOST = "inference.tinfoil.sh"
 
 
 _CERTIFICATE_VERIFY_ERROR_MARKERS = (
@@ -88,34 +87,6 @@ def _url_origin(url: str) -> tuple[str, str, int]:
     default_port = 443 if scheme == "https" else 80
     port = parsed.port if parsed.port is not None else default_port
     return scheme, parsed.hostname or "", port
-
-
-def _resolve_enclave_for_base_url(base_url: str, enclave: str) -> str:
-    """Bind the legacy inference endpoint to its matching enclave identity."""
-    if not base_url or _url_origin(base_url) != (
-        "https",
-        DEFAULT_INFERENCE_HOST,
-        443,
-    ):
-        return enclave
-
-    if not enclave:
-        # inference.tinfoil.sh is a stable enclave identity, not a proxy that
-        # forwards X-Tinfoil-Enclave-Url. Its HPKE bundle must therefore be
-        # fetched explicitly instead of combining this destination with a
-        # randomly selected default-router key.
-        return DEFAULT_INFERENCE_HOST
-
-    if _url_origin(f"https://{enclave}") != (
-        "https",
-        DEFAULT_INFERENCE_HOST,
-        443,
-    ):
-        raise ValueError(
-            f"base_url {base_url!r} cannot route to enclave {enclave!r}; "
-            f"use a proxy that forwards {ENCLAVE_URL_HEADER} or connect directly"
-        )
-    return DEFAULT_INFERENCE_HOST
 
 
 class _PinMismatchError(ValueError):
@@ -470,6 +441,7 @@ class _EHBPReVerifyingTransport(httpx.BaseTransport):
                 raise
 
             assert retry_inner is not None
+            _update_enclave_header(request, self._secure_client)
             try:
                 return retry_inner.handle_request(request)
             finally:
@@ -513,6 +485,7 @@ class _AsyncEHBPReVerifyingTransport(httpx.AsyncBaseTransport):
                 raise
 
             assert retry_inner is not None
+            _update_enclave_header(request, self._secure_client)
             try:
                 return await retry_inner.handle_async_request(request)
             finally:
@@ -538,6 +511,15 @@ def _enclave_url_header(base_url: str, enclave: str) -> tuple[str, bool]:
     return enclave_url, True
 
 
+def _update_enclave_header(request: httpx.Request, client: "SecureClient") -> None:
+    """Bind a replayed request to the endpoint selected by re-verification."""
+    value, inject = _enclave_url_header(client.base_url, client.enclave)
+    if inject:
+        request.headers[ENCLAVE_URL_HEADER] = value
+    else:
+        request.headers.pop(ENCLAVE_URL_HEADER, None)
+
+
 class _EnclaveURLHeaderTransport(httpx.BaseTransport):
     """
     Injects the X-Tinfoil-Enclave-Url header before delegating to the wrapped
@@ -554,9 +536,7 @@ class _EnclaveURLHeaderTransport(httpx.BaseTransport):
         self._client = client
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
-        header_value, inject = _enclave_url_header(self._client.base_url, self._client.enclave)
-        if inject:
-            request.headers[ENCLAVE_URL_HEADER] = header_value
+        _update_enclave_header(request, self._client)
         return self._inner.handle_request(request)
 
     def close(self) -> None:
@@ -571,9 +551,7 @@ class _AsyncEnclaveURLHeaderTransport(httpx.AsyncBaseTransport):
         self._client = client
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        header_value, inject = _enclave_url_header(self._client.base_url, self._client.enclave)
-        if inject:
-            request.headers[ENCLAVE_URL_HEADER] = header_value
+        _update_enclave_header(request, self._client)
         return await self._inner.handle_async_request(request)
 
     async def aclose(self) -> None:
@@ -647,7 +625,6 @@ class SecureClient:
                 https_only=True,
             )
 
-        enclave = _resolve_enclave_for_base_url(base_url or "", enclave or "")
         # Keep the caller's routing constraint separate from the currently
         # verified endpoint. A bundle-discovered endpoint may change when a
         # proxy client recovers from an HPKE key mismatch.

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -413,35 +413,42 @@ class _EHBPReVerifyingTransport(httpx.BaseTransport):
 
     def __init__(self, secure_client: "SecureClient", inner: httpx.BaseTransport):
         self._secure_client = secure_client
-        self._inner = inner
+        # Treat the sealing transport and its verified route as one immutable
+        # generation. Reading a single tuple prevents a concurrent, later
+        # rotation from pairing this generation's key with another endpoint.
+        self._state = (inner, secure_client.enclave)
         self._lock = threading.Lock()
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
-        inner = self._inner
+        state = self._state
+        inner, enclave = state
+        _update_enclave_header(request, self._secure_client, enclave)
         try:
             return inner.handle_request(request)
         except KeyConfigMismatchError:
             old_inner: Optional[httpx.BaseTransport] = None
-            retry_inner: Optional[httpx.BaseTransport] = None
+            retry_state: Optional[tuple[httpx.BaseTransport, str]] = None
             reverify_failed = False
             with self._lock:
-                if self._inner is inner:
+                if self._state is state:
                     try:
                         retry_inner = self._secure_client._build_ehbp_sync_transport()
                     except Exception:
                         # Re-verification failed; surface the original mismatch.
                         reverify_failed = True
                     else:
-                        old_inner = self._inner
-                        self._inner = retry_inner
+                        old_inner = state[0]
+                        retry_state = (retry_inner, self._secure_client.enclave)
+                        self._state = retry_state
                 else:
-                    retry_inner = self._inner
+                    retry_state = self._state
 
             if reverify_failed:
                 raise
 
-            assert retry_inner is not None
-            _update_enclave_header(request, self._secure_client)
+            assert retry_state is not None
+            retry_inner, retry_enclave = retry_state
+            _update_enclave_header(request, self._secure_client, retry_enclave)
             try:
                 return retry_inner.handle_request(request)
             finally:
@@ -450,7 +457,7 @@ class _EHBPReVerifyingTransport(httpx.BaseTransport):
                         old_inner.close()
 
     def close(self) -> None:
-        self._inner.close()
+        self._state[0].close()
 
 
 class _AsyncEHBPReVerifyingTransport(httpx.AsyncBaseTransport):
@@ -458,34 +465,38 @@ class _AsyncEHBPReVerifyingTransport(httpx.AsyncBaseTransport):
 
     def __init__(self, secure_client: "SecureClient", inner: httpx.AsyncBaseTransport):
         self._secure_client = secure_client
-        self._inner = inner
+        self._state = (inner, secure_client.enclave)
         self._lock = asyncio.Lock()
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        inner = self._inner
+        state = self._state
+        inner, enclave = state
+        _update_enclave_header(request, self._secure_client, enclave)
         try:
             return await inner.handle_async_request(request)
         except KeyConfigMismatchError:
             old_inner: Optional[httpx.AsyncBaseTransport] = None
-            retry_inner: Optional[httpx.AsyncBaseTransport] = None
+            retry_state: Optional[tuple[httpx.AsyncBaseTransport, str]] = None
             reverify_failed = False
             async with self._lock:
-                if self._inner is inner:
+                if self._state is state:
                     try:
                         retry_inner = await self._secure_client._build_ehbp_async_transport()
                     except Exception:
                         reverify_failed = True
                     else:
-                        old_inner = self._inner
-                        self._inner = retry_inner
+                        old_inner = state[0]
+                        retry_state = (retry_inner, self._secure_client.enclave)
+                        self._state = retry_state
                 else:
-                    retry_inner = self._inner
+                    retry_state = self._state
 
             if reverify_failed:
                 raise
 
-            assert retry_inner is not None
-            _update_enclave_header(request, self._secure_client)
+            assert retry_state is not None
+            retry_inner, retry_enclave = retry_state
+            _update_enclave_header(request, self._secure_client, retry_enclave)
             try:
                 return await retry_inner.handle_async_request(request)
             finally:
@@ -494,7 +505,7 @@ class _AsyncEHBPReVerifyingTransport(httpx.AsyncBaseTransport):
                         await old_inner.aclose()
 
     async def aclose(self) -> None:
-        await self._inner.aclose()
+        await self._state[0].aclose()
 
 
 def _enclave_url_header(base_url: str, enclave: str) -> tuple[str, bool]:
@@ -511,9 +522,16 @@ def _enclave_url_header(base_url: str, enclave: str) -> tuple[str, bool]:
     return enclave_url, True
 
 
-def _update_enclave_header(request: httpx.Request, client: "SecureClient") -> None:
-    """Bind a replayed request to the endpoint selected by re-verification."""
-    value, inject = _enclave_url_header(client.base_url, client.enclave)
+def _update_enclave_header(
+    request: httpx.Request,
+    client: "SecureClient",
+    enclave: Optional[str] = None,
+) -> None:
+    """Bind a request to the endpoint paired with its sealing transport."""
+    value, inject = _enclave_url_header(
+        client.base_url,
+        client.enclave if enclave is None else enclave,
+    )
     if inject:
         request.headers[ENCLAVE_URL_HEADER] = value
     else:
@@ -756,8 +774,6 @@ class SecureClient:
     ) -> httpx.BaseTransport:
         if self._user_cache_secret:
             transport = _UserCacheSecretTransport(self._user_cache_secret, transport)
-        if self.transport == "ehbp" and self.base_url:
-            transport = _EnclaveURLHeaderTransport(transport, self)
         return _HostBoundTransport(transport, self)
 
     def _wrap_async_transport(
@@ -767,8 +783,6 @@ class SecureClient:
             transport = _AsyncUserCacheSecretTransport(
                 self._user_cache_secret, transport
             )
-        if self.transport == "ehbp" and self.base_url:
-            transport = _AsyncEnclaveURLHeaderTransport(transport, self)
         return _AsyncHostBoundTransport(transport, self)
 
     def make_secure_http_client(self) -> httpx.Client:

--- a/src/tinfoil/client.py
+++ b/src/tinfoil/client.py
@@ -47,6 +47,7 @@ from .user_cache_secret import (
 ENCLAVE_URL_HEADER = "X-Tinfoil-Enclave-Url"
 
 DEFAULT_CONFIG_REPO = "tinfoilsh/confidential-model-router"
+DEFAULT_INFERENCE_HOST = "inference.tinfoil.sh"
 
 
 _CERTIFICATE_VERIFY_ERROR_MARKERS = (
@@ -87,6 +88,34 @@ def _url_origin(url: str) -> tuple[str, str, int]:
     default_port = 443 if scheme == "https" else 80
     port = parsed.port if parsed.port is not None else default_port
     return scheme, parsed.hostname or "", port
+
+
+def _resolve_enclave_for_base_url(base_url: str, enclave: str) -> str:
+    """Bind the legacy inference endpoint to its matching enclave identity."""
+    if not base_url or _url_origin(base_url) != (
+        "https",
+        DEFAULT_INFERENCE_HOST,
+        443,
+    ):
+        return enclave
+
+    if not enclave:
+        # inference.tinfoil.sh is a stable enclave identity, not a proxy that
+        # forwards X-Tinfoil-Enclave-Url. Its HPKE bundle must therefore be
+        # fetched explicitly instead of combining this destination with a
+        # randomly selected default-router key.
+        return DEFAULT_INFERENCE_HOST
+
+    if _url_origin(f"https://{enclave}") != (
+        "https",
+        DEFAULT_INFERENCE_HOST,
+        443,
+    ):
+        raise ValueError(
+            f"base_url {base_url!r} cannot route to enclave {enclave!r}; "
+            f"use a proxy that forwards {ENCLAVE_URL_HEADER} or connect directly"
+        )
+    return DEFAULT_INFERENCE_HOST
 
 
 class _PinMismatchError(ValueError):
@@ -618,6 +647,12 @@ class SecureClient:
                 https_only=True,
             )
 
+        enclave = _resolve_enclave_for_base_url(base_url or "", enclave or "")
+        # Keep the caller's routing constraint separate from the currently
+        # verified endpoint. A bundle-discovered endpoint may change when a
+        # proxy client recovers from an HPKE key mismatch.
+        self._configured_enclave = enclave
+
         # If enclave is empty, fetch a random one from the routers API. When
         # attesting from a bundle, the enclave host comes from the verified
         # bundle, so no router lookup is needed.
@@ -849,8 +884,14 @@ class SecureClient:
         # for an enclave/repo-specific bundle when either is set.
         if self.attestation_bundle_url:
             repo = self.repo if self.repo != DEFAULT_CONFIG_REPO else ""
+            requested_enclave = self._bundle_request_enclave()
             return self.verify_from_bundle(
-                fetch_bundle_from(self.attestation_bundle_url, enclave=self.enclave, repo=repo)
+                fetch_bundle_from(
+                    self.attestation_bundle_url,
+                    enclave=requested_enclave,
+                    repo=repo,
+                ),
+                expected_enclave=requested_enclave,
             )
 
         doc = VerificationDocument(
@@ -948,13 +989,41 @@ class SecureClient:
 
             return self._finalize_verification(doc, verification, digest)
 
-    def verify_from_bundle(self, bundle: Bundle) -> GroundTruth:
+    def _bundle_request_enclave(self) -> str:
+        """Return routing constraints without pinning proxy discoveries."""
+        if self._configured_enclave:
+            return self._configured_enclave
+        if self.base_url:
+            # A real EHBP proxy can follow the per-request enclave header, so a
+            # retry may rotate the complete endpoint/key pair.
+            return ""
+        # Direct clients have a fixed request destination. Once selected, fetch
+        # that domain's fresh bundle instead of pairing it with another key.
+        return self.enclave
+
+    def verify_from_bundle(
+        self,
+        bundle: Bundle,
+        *,
+        expected_enclave: str = "",
+    ) -> GroundTruth:
         """
         Verifies a pre-fetched attestation bundle entirely client-side and
         stores the ground truth. The bundle supplies the enclave attestation
         report, release digest, Sigstore bundle, AMD VCEK, and enclave TLS
         certificate, so verification needs no direct connection to the enclave.
         """
+        constrained_enclave = expected_enclave or self._configured_enclave
+        if (
+            constrained_enclave
+            and bundle.domain.casefold().rstrip(".")
+            != constrained_enclave.casefold().rstrip(".")
+        ):
+            raise ValueError(
+                f"attestation bundle domain {bundle.domain!r} does not match "
+                f"configured enclave {constrained_enclave!r}"
+            )
+
         doc = VerificationDocument(
             config_repo=self.repo or "",
             enclave_host=bundle.domain,

--- a/tests/test_encrypted_proxy.py
+++ b/tests/test_encrypted_proxy.py
@@ -26,6 +26,7 @@ from tinfoil.attestation import Bundle, Document, fetch_bundle_from
 from tinfoil.attestation.bundle import _decode_domains, _matches_hostname
 from tinfoil.attestation.types import Measurement, PredicateType, Verification
 from tinfoil.client import (
+    DEFAULT_INFERENCE_HOST,
     ENCLAVE_URL_HEADER,
     GroundTruth,
     _AsyncEHBPReVerifyingTransport,
@@ -35,6 +36,7 @@ from tinfoil.client import (
     _EnclaveURLHeaderTransport,
     _HostBoundTransport,
     _enclave_url_header,
+    _resolve_enclave_for_base_url,
 )
 from tinfoil.user_cache_secret import (
     _AsyncUserCacheSecretTransport,
@@ -426,6 +428,88 @@ class TestConstructorValidation:
     def test_https_attestation_bundle_url_is_accepted(self):
         sc = SecureClient(attestation_bundle_url="https://atc.example")
         assert sc.attestation_bundle_url == "https://atc.example"
+
+    def test_official_inference_base_uses_matching_enclave(self):
+        sc = SecureClient(
+            base_url="https://INFERENCE.TINFOIL.SH:443/v1/",
+            attestation_bundle_url="https://atc.example",
+        )
+        assert sc.enclave == DEFAULT_INFERENCE_HOST
+        assert sc._configured_enclave == DEFAULT_INFERENCE_HOST
+
+    def test_official_inference_base_rejects_another_enclave(self):
+        with pytest.raises(ValueError, match="cannot route"):
+            SecureClient(
+                enclave="router.example.com",
+                base_url="https://inference.tinfoil.sh/v1/",
+                attestation_bundle_url="https://atc.example",
+            )
+
+    def test_custom_proxy_preserves_automatic_selection(self):
+        sc = SecureClient(
+            base_url="https://proxy.example.com/v1/",
+            attestation_bundle_url="https://atc.example",
+        )
+        assert sc.enclave == ""
+        assert sc._configured_enclave == ""
+
+
+class TestBundleRecoveryRouting:
+    def test_proxy_recovery_can_rotate_complete_router_identity(self):
+        sc = SecureClient(
+            base_url="https://proxy.example.com/v1/",
+            attestation_bundle_url="https://atc.example",
+        )
+        sc.enclave = "old-router.example"
+        assert sc._bundle_request_enclave() == ""
+
+    def test_direct_recovery_refetches_current_domains_bundle(self):
+        sc = SecureClient(attestation_bundle_url="https://atc.example")
+        sc.enclave = "selected-router.example"
+        assert sc._bundle_request_enclave() == "selected-router.example"
+
+    def test_explicit_enclave_remains_pinned(self):
+        sc = SecureClient(
+            enclave="configured.example",
+            base_url="https://proxy.example.com/v1/",
+            attestation_bundle_url="https://atc.example",
+        )
+        sc.enclave = "configured.example"
+        assert sc._bundle_request_enclave() == "configured.example"
+
+    def test_configured_bundle_domain_mismatch_is_rejected_before_verification(self):
+        sc = SecureClient(
+            enclave="configured.example",
+            attestation_bundle_url="https://atc.example",
+        )
+        with pytest.raises(ValueError, match="does not match configured enclave"):
+            sc.verify_from_bundle(
+                Bundle(
+                    domain="other.example",
+                    enclave_attestation_report=Document(
+                        format=PredicateType.SEV_GUEST_V2,
+                        body="Zm9v",
+                    ),
+                    digest="",
+                    sigstore_bundle=b"",
+                    vcek="",
+                    enclave_cert="",
+                )
+            )
+
+
+class TestOfficialInferenceResolution:
+    @pytest.mark.parametrize(
+        "base_url,enclave,want",
+        [
+            ("https://inference.tinfoil.sh/v1/", "", DEFAULT_INFERENCE_HOST),
+            ("https://INFERENCE.TINFOIL.SH:443/v1/", DEFAULT_INFERENCE_HOST, DEFAULT_INFERENCE_HOST),
+            ("https://proxy.example.com/v1/", "", ""),
+            ("http://inference.tinfoil.sh/v1/", "", ""),
+        ],
+    )
+    def test_resolution(self, base_url, enclave, want):
+        assert _resolve_enclave_for_base_url(base_url, enclave) == want
 
 
 class TestBundleModeRequestRouting:

--- a/tests/test_encrypted_proxy.py
+++ b/tests/test_encrypted_proxy.py
@@ -29,6 +29,7 @@ from tinfoil.client import (
     DEFAULT_INFERENCE_HOST,
     ENCLAVE_URL_HEADER,
     GroundTruth,
+    VerificationDocument,
     _AsyncEHBPReVerifyingTransport,
     _AsyncEnclaveURLHeaderTransport,
     _AsyncHostBoundTransport,
@@ -482,7 +483,9 @@ class TestBundleRecoveryRouting:
             enclave="configured.example",
             attestation_bundle_url="https://atc.example",
         )
-        with pytest.raises(ValueError, match="does not match configured enclave"):
+        sc._verification_document = VerificationDocument(security_verified=True)
+
+        with pytest.raises(ValueError, match="does not match configured enclave") as exc_info:
             sc.verify_from_bundle(
                 Bundle(
                     domain="other.example",
@@ -495,6 +498,34 @@ class TestBundleRecoveryRouting:
                     vcek="",
                     enclave_cert="",
                 )
+            )
+
+        document = sc.get_verification_document()
+        assert not document.security_verified
+        assert document.enclave_host == "other.example"
+        assert document.steps["verify_enclave"].status == "failed"
+        assert getattr(exc_info.value, "verification_document") == document
+
+    def test_retry_expectation_cannot_override_configured_enclave(self):
+        sc = SecureClient(
+            enclave="configured.example",
+            attestation_bundle_url="https://atc.example",
+        )
+
+        with pytest.raises(ValueError, match=r"configured\.example"):
+            sc.verify_from_bundle(
+                Bundle(
+                    domain="retry-selected.example",
+                    enclave_attestation_report=Document(
+                        format=PredicateType.SEV_GUEST_V2,
+                        body="Zm9v",
+                    ),
+                    digest="",
+                    sigstore_bundle=b"",
+                    vcek="",
+                    enclave_cert="",
+                ),
+                expected_enclave="retry-selected.example",
             )
 
 

--- a/tests/test_encrypted_proxy.py
+++ b/tests/test_encrypted_proxy.py
@@ -22,6 +22,7 @@ from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from ehbp import KeyConfigMismatchError
 
 import tinfoil as tinfoil_module
+import tinfoil.client as client_module
 from tinfoil import AsyncTinfoilAI, SecureClient, TinfoilAI
 from tinfoil.attestation import Bundle, Document, fetch_bundle_from
 from tinfoil.attestation.bundle import _decode_domains, _matches_hostname
@@ -152,7 +153,7 @@ class TestEnclaveURLHeaderTransport:
         )
         assert inner.seen_header == "https://new.example.com"
 
-    def test_sync_retry_uses_rotated_enclave_header(self):
+    def test_sync_retry_uses_endpoint_bound_to_rebuilt_transport(self):
         sc = self._client("old.example.com", "https://proxy.example.com/")
         recovered = _RecordingTransport()
 
@@ -161,17 +162,30 @@ class TestEnclaveURLHeaderTransport:
             return recovered
 
         sc._build_ehbp_sync_transport = MagicMock(side_effect=rebuild)
-        transport = _EnclaveURLHeaderTransport(
-            _EHBPReVerifyingTransport(sc, _KeyMismatchTransport()), sc
-        )
-        response = transport.handle_request(
-            httpx.Request("POST", "https://proxy.example.com/v1/x", content=b"p")
-        )
+        transport = _EHBPReVerifyingTransport(sc, _KeyMismatchTransport())
+        update_header = client_module._update_enclave_header
+
+        def rotate_global_state_again(request, client, enclave=None):
+            if enclave == "new.example.com":
+                # Simulate another request installing a later generation after
+                # this request selected its transport but before replay.
+                sc.enclave = "later.example.com"
+            update_header(request, client, enclave)
+
+        with patch.object(
+            client_module,
+            "_update_enclave_header",
+            side_effect=rotate_global_state_again,
+        ):
+            response = transport.handle_request(
+                httpx.Request("POST", "https://proxy.example.com/v1/x", content=b"p")
+            )
 
         assert response.status_code == 200
         assert recovered.seen_header == "https://new.example.com"
+        assert sc.enclave == "later.example.com"
 
-    def test_async_retry_uses_rotated_enclave_header(self):
+    def test_async_retry_uses_endpoint_bound_to_rebuilt_transport(self):
         async def run():
             sc = self._client("old.example.com", "https://proxy.example.com/")
             recovered = _AsyncRecordingTransport()
@@ -181,57 +195,65 @@ class TestEnclaveURLHeaderTransport:
                 return recovered
 
             sc._build_ehbp_async_transport = rebuild
-            transport = _AsyncEnclaveURLHeaderTransport(
-                _AsyncEHBPReVerifyingTransport(
-                    sc, _AsyncKeyMismatchTransport()
-                ),
-                sc,
+            transport = _AsyncEHBPReVerifyingTransport(
+                sc, _AsyncKeyMismatchTransport()
             )
-            response = await transport.handle_async_request(
-                httpx.Request(
-                    "POST", "https://proxy.example.com/v1/x", content=b"p"
+            update_header = client_module._update_enclave_header
+
+            def rotate_global_state_again(request, client, enclave=None):
+                if enclave == "new.example.com":
+                    sc.enclave = "later.example.com"
+                update_header(request, client, enclave)
+
+            with patch.object(
+                client_module,
+                "_update_enclave_header",
+                side_effect=rotate_global_state_again,
+            ):
+                response = await transport.handle_async_request(
+                    httpx.Request(
+                        "POST", "https://proxy.example.com/v1/x", content=b"p"
+                    )
                 )
-            )
 
             assert response.status_code == 200
             assert recovered.seen_header == "https://new.example.com"
+            assert sc.enclave == "later.example.com"
 
         asyncio.run(run())
 
 
 class TestProxyTransportWiring:
-    """make_secure_http_client wraps the EHBP transport with the header
-    transport only when routing through a proxy of a different origin."""
+    """The EHBP generation owns both its sealing key and proxy route."""
 
     def _client(self, base_url: str | None):
         sc = SecureClient(enclave="enclave.test", repo="org/repo", transport="ehbp", base_url=base_url)
         sc.verify = MagicMock(return_value=_ground_truth(_valid_hpke_hex()))
         return sc
 
-    def test_sync_wraps_when_proxying(self):
+    def test_sync_binds_proxy_route_inside_ehbp_generation(self):
         sc = self._client("http://proxy.example.com/")
         client = sc.make_secure_http_client()
         try:
             # The user-cache-secret layer injects into the body before the
             # EHBP re-verifying transport seals it.
             assert isinstance(client._transport, _HostBoundTransport)
-            header = client._transport._inner
-            assert isinstance(header, _EnclaveURLHeaderTransport)
-            ucs = header._inner
+            ucs = client._transport._inner
             assert isinstance(ucs, _UserCacheSecretTransport)
             assert isinstance(ucs._inner, _EHBPReVerifyingTransport)
         finally:
             client.close()
 
-    def test_sync_wraps_even_when_same_origin(self):
-        # With base_url set the header transport is always installed; it decides
-        # per request whether to inject, since the enclave can change after a
-        # re-verification.
+    def test_sync_same_origin_uses_the_same_generation_model(self):
         sc = self._client("https://enclave.test/v1/")
         client = sc.make_secure_http_client()
         try:
             assert isinstance(client._transport, _HostBoundTransport)
-            assert isinstance(client._transport._inner, _EnclaveURLHeaderTransport)
+            assert isinstance(client._transport._inner, _UserCacheSecretTransport)
+            assert isinstance(
+                client._transport._inner._inner,
+                _EHBPReVerifyingTransport,
+            )
         finally:
             client.close()
 
@@ -247,14 +269,12 @@ class TestProxyTransportWiring:
         finally:
             client.close()
 
-    def test_async_wraps_when_proxying(self):
+    def test_async_binds_proxy_route_inside_ehbp_generation(self):
         sc = self._client("https://proxy.example.com/")
         client = sc.make_secure_async_http_client()
         try:
             assert isinstance(client._transport, _AsyncHostBoundTransport)
-            header = client._transport._inner
-            assert isinstance(header, _AsyncEnclaveURLHeaderTransport)
-            ucs = header._inner
+            ucs = client._transport._inner
             assert isinstance(ucs, _AsyncUserCacheSecretTransport)
             assert isinstance(ucs._inner, _AsyncEHBPReVerifyingTransport)
         finally:

--- a/tests/test_encrypted_proxy.py
+++ b/tests/test_encrypted_proxy.py
@@ -19,6 +19,7 @@ import httpx
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+from ehbp import KeyConfigMismatchError
 
 import tinfoil as tinfoil_module
 from tinfoil import AsyncTinfoilAI, SecureClient, TinfoilAI
@@ -26,7 +27,6 @@ from tinfoil.attestation import Bundle, Document, fetch_bundle_from
 from tinfoil.attestation.bundle import _decode_domains, _matches_hostname
 from tinfoil.attestation.types import Measurement, PredicateType, Verification
 from tinfoil.client import (
-    DEFAULT_INFERENCE_HOST,
     ENCLAVE_URL_HEADER,
     GroundTruth,
     VerificationDocument,
@@ -37,7 +37,6 @@ from tinfoil.client import (
     _EnclaveURLHeaderTransport,
     _HostBoundTransport,
     _enclave_url_header,
-    _resolve_enclave_for_base_url,
 )
 from tinfoil.user_cache_secret import (
     _AsyncUserCacheSecretTransport,
@@ -91,6 +90,18 @@ class _AsyncRecordingTransport(httpx.AsyncBaseTransport):
         return httpx.Response(200, content=b"ok")
 
 
+class _KeyMismatchTransport(httpx.BaseTransport):
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        request.read()
+        raise KeyConfigMismatchError("rotated")
+
+
+class _AsyncKeyMismatchTransport(httpx.AsyncBaseTransport):
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        await request.aread()
+        raise KeyConfigMismatchError("rotated")
+
+
 class TestEnclaveURLHeaderTransport:
     def _client(self, enclave: str, base_url: str):
         return SecureClient(enclave=enclave, repo="org/repo", transport="ehbp", base_url=base_url)
@@ -140,6 +151,52 @@ class TestEnclaveURLHeaderTransport:
             httpx.Request("POST", "https://proxy.example.com/v1/x", content=b"p")
         )
         assert inner.seen_header == "https://new.example.com"
+
+    def test_sync_retry_uses_rotated_enclave_header(self):
+        sc = self._client("old.example.com", "https://proxy.example.com/")
+        recovered = _RecordingTransport()
+
+        def rebuild():
+            sc.enclave = "new.example.com"
+            return recovered
+
+        sc._build_ehbp_sync_transport = MagicMock(side_effect=rebuild)
+        transport = _EnclaveURLHeaderTransport(
+            _EHBPReVerifyingTransport(sc, _KeyMismatchTransport()), sc
+        )
+        response = transport.handle_request(
+            httpx.Request("POST", "https://proxy.example.com/v1/x", content=b"p")
+        )
+
+        assert response.status_code == 200
+        assert recovered.seen_header == "https://new.example.com"
+
+    def test_async_retry_uses_rotated_enclave_header(self):
+        async def run():
+            sc = self._client("old.example.com", "https://proxy.example.com/")
+            recovered = _AsyncRecordingTransport()
+
+            async def rebuild():
+                sc.enclave = "new.example.com"
+                return recovered
+
+            sc._build_ehbp_async_transport = rebuild
+            transport = _AsyncEnclaveURLHeaderTransport(
+                _AsyncEHBPReVerifyingTransport(
+                    sc, _AsyncKeyMismatchTransport()
+                ),
+                sc,
+            )
+            response = await transport.handle_async_request(
+                httpx.Request(
+                    "POST", "https://proxy.example.com/v1/x", content=b"p"
+                )
+            )
+
+            assert response.status_code == 200
+            assert recovered.seen_header == "https://new.example.com"
+
+        asyncio.run(run())
 
 
 class TestProxyTransportWiring:
@@ -430,22 +487,6 @@ class TestConstructorValidation:
         sc = SecureClient(attestation_bundle_url="https://atc.example")
         assert sc.attestation_bundle_url == "https://atc.example"
 
-    def test_official_inference_base_uses_matching_enclave(self):
-        sc = SecureClient(
-            base_url="https://INFERENCE.TINFOIL.SH:443/v1/",
-            attestation_bundle_url="https://atc.example",
-        )
-        assert sc.enclave == DEFAULT_INFERENCE_HOST
-        assert sc._configured_enclave == DEFAULT_INFERENCE_HOST
-
-    def test_official_inference_base_rejects_another_enclave(self):
-        with pytest.raises(ValueError, match="cannot route"):
-            SecureClient(
-                enclave="router.example.com",
-                base_url="https://inference.tinfoil.sh/v1/",
-                attestation_bundle_url="https://atc.example",
-            )
-
     def test_custom_proxy_preserves_automatic_selection(self):
         sc = SecureClient(
             base_url="https://proxy.example.com/v1/",
@@ -527,20 +568,6 @@ class TestBundleRecoveryRouting:
                 ),
                 expected_enclave="retry-selected.example",
             )
-
-
-class TestOfficialInferenceResolution:
-    @pytest.mark.parametrize(
-        "base_url,enclave,want",
-        [
-            ("https://inference.tinfoil.sh/v1/", "", DEFAULT_INFERENCE_HOST),
-            ("https://INFERENCE.TINFOIL.SH:443/v1/", DEFAULT_INFERENCE_HOST, DEFAULT_INFERENCE_HOST),
-            ("https://proxy.example.com/v1/", "", ""),
-            ("http://inference.tinfoil.sh/v1/", "", ""),
-        ],
-    )
-    def test_resolution(self, base_url, enclave, want):
-        assert _resolve_enclave_for_base_url(base_url, enclave) == want
 
 
 class TestBundleModeRequestRouting:

--- a/tests/test_encrypted_proxy.py
+++ b/tests/test_encrypted_proxy.py
@@ -32,10 +32,8 @@ from tinfoil.client import (
     GroundTruth,
     VerificationDocument,
     _AsyncEHBPReVerifyingTransport,
-    _AsyncEnclaveURLHeaderTransport,
     _AsyncHostBoundTransport,
     _EHBPReVerifyingTransport,
-    _EnclaveURLHeaderTransport,
     _HostBoundTransport,
     _enclave_url_header,
 )
@@ -103,55 +101,9 @@ class _AsyncKeyMismatchTransport(httpx.AsyncBaseTransport):
         raise KeyConfigMismatchError("rotated")
 
 
-class TestEnclaveURLHeaderTransport:
+class TestEHBPRouteGeneration:
     def _client(self, enclave: str, base_url: str):
         return SecureClient(enclave=enclave, repo="org/repo", transport="ehbp", base_url=base_url)
-
-    def test_sync_injects_header(self):
-        inner = _RecordingTransport()
-        sc = self._client("enclave.example.com", "https://proxy.example.com/")
-        transport = _EnclaveURLHeaderTransport(inner, sc)
-        request = httpx.Request("POST", "https://proxy.example.com/v1/chat/completions", content=b"payload")
-        resp = transport.handle_request(request)
-        assert resp.status_code == 200
-        assert inner.seen_header == "https://enclave.example.com"
-
-    def test_async_injects_header(self):
-        async def run():
-            inner = _AsyncRecordingTransport()
-            sc = self._client("enclave.example.com", "https://proxy.example.com/")
-            transport = _AsyncEnclaveURLHeaderTransport(inner, sc)
-            request = httpx.Request("POST", "https://proxy.example.com/v1/chat/completions", content=b"payload")
-            resp = await transport.handle_async_request(request)
-            assert resp.status_code == 200
-            assert inner.seen_header == "https://enclave.example.com"
-
-        asyncio.run(run())
-
-    def test_no_header_when_same_origin(self):
-        inner = _RecordingTransport()
-        sc = self._client("enclave.test", "https://enclave.test/v1/")
-        transport = _EnclaveURLHeaderTransport(inner, sc)
-        transport.handle_request(
-            httpx.Request("POST", "https://enclave.test/v1/chat/completions", content=b"payload")
-        )
-        assert inner.seen_header is None
-
-    def test_reflects_enclave_change_after_reverification(self):
-        inner = _RecordingTransport()
-        sc = self._client("old.example.com", "https://proxy.example.com/")
-        transport = _EnclaveURLHeaderTransport(inner, sc)
-        transport.handle_request(
-            httpx.Request("POST", "https://proxy.example.com/v1/x", content=b"p")
-        )
-        assert inner.seen_header == "https://old.example.com"
-        # A re-verification (e.g. bundle mode behind a proxy) may swap in a
-        # different enclave; the header must follow the current enclave.
-        sc.enclave = "new.example.com"
-        transport.handle_request(
-            httpx.Request("POST", "https://proxy.example.com/v1/x", content=b"p")
-        )
-        assert inner.seen_header == "https://new.example.com"
 
     def test_sync_retry_uses_endpoint_bound_to_rebuilt_transport(self):
         sc = self._client("old.example.com", "https://proxy.example.com/")
@@ -165,12 +117,12 @@ class TestEnclaveURLHeaderTransport:
         transport = _EHBPReVerifyingTransport(sc, _KeyMismatchTransport())
         update_header = client_module._update_enclave_header
 
-        def rotate_global_state_again(request, client, enclave=None):
+        def rotate_global_state_again(request, base_url, enclave):
             if enclave == "new.example.com":
                 # Simulate another request installing a later generation after
                 # this request selected its transport but before replay.
                 sc.enclave = "later.example.com"
-            update_header(request, client, enclave)
+            update_header(request, base_url, enclave)
 
         with patch.object(
             client_module,
@@ -200,10 +152,10 @@ class TestEnclaveURLHeaderTransport:
             )
             update_header = client_module._update_enclave_header
 
-            def rotate_global_state_again(request, client, enclave=None):
+            def rotate_global_state_again(request, base_url, enclave):
                 if enclave == "new.example.com":
                     sc.enclave = "later.example.com"
-                update_header(request, client, enclave)
+                update_header(request, base_url, enclave)
 
             with patch.object(
                 client_module,


### PR DESCRIPTION
## Summary

- separate the caller-configured enclave constraint from the bundle-discovered runtime endpoint
- remove every SDK special case for inference.tinfoil.sh
- bind each EHBP sealing transport and verified proxy route in one immutable generation
- allow a real forwarding proxy to refresh the complete attested endpoint and HPKE key pair
- keep direct clients on the selected domain and explicitly configured clients pinned
- reject bundle-domain mismatches before accepting verification state
- delete the obsolete standalone header-routing layer and its dead tests

## Security

A request is replayed only after the protocol-defined EHBP key-configuration mismatch signal. Replacement state must pass complete client-side attestation, and concurrent rotations cannot pair one generation's key with another generation's route.

## Validation

- 482 non-integration tests passed
- 2 skipped, 24 live integration tests deselected
- git diff --check